### PR TITLE
Add workspace deletion with confirmation dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,7 @@ function MainApp() {
     connectWorkspace,
     markWorkspaceConnected,
     updateWorkspaceSettings,
+    removeWorkspace,
     hasLoaded,
     refreshWorkspaces,
   } = useWorkspaces({ onDebug: addDebugEntry });
@@ -354,6 +355,9 @@ function MainApp() {
         }}
         onDeleteThread={(workspaceId, threadId) => {
           removeThread(workspaceId, threadId);
+        }}
+        onDeleteWorkspace={(workspaceId) => {
+          void removeWorkspace(workspaceId);
         }}
       />
       <div

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ type SidebarProps = {
   onToggleWorkspaceCollapse: (workspaceId: string, collapsed: boolean) => void;
   onSelectThread: (workspaceId: string, threadId: string) => void;
   onDeleteThread: (workspaceId: string, threadId: string) => void;
+  onDeleteWorkspace: (workspaceId: string) => void;
 };
 
 export function Sidebar({
@@ -41,6 +42,7 @@ export function Sidebar({
   onToggleWorkspaceCollapse,
   onSelectThread,
   onDeleteThread,
+  onDeleteWorkspace,
 }: SidebarProps) {
   const [expandedWorkspaces, setExpandedWorkspaces] = useState(
     new Set<string>(),
@@ -64,6 +66,22 @@ export function Sidebar({
       },
     });
     const menu = await Menu.new({ items: [copyItem, archiveItem] });
+    const window = getCurrentWindow();
+    const position = new LogicalPosition(event.clientX, event.clientY);
+    await menu.popup(position, window);
+  }
+
+  async function showWorkspaceMenu(
+    event: React.MouseEvent,
+    workspaceId: string,
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+    const deleteItem = await MenuItem.new({
+      text: "Delete",
+      action: () => onDeleteWorkspace(workspaceId),
+    });
+    const menu = await Menu.new({ items: [deleteItem] });
     const window = getCurrentWindow();
     const position = new LogicalPosition(event.clientX, event.clientY);
     await menu.popup(position, window);
@@ -150,6 +168,7 @@ export function Sidebar({
                   role="button"
                   tabIndex={0}
                   onClick={() => onSelectWorkspace(entry.id)}
+                  onContextMenu={(event) => showWorkspaceMenu(event, entry.id)}
                   onKeyDown={(event) => {
                     if (event.key === "Enter" || event.key === " ") {
                       event.preventDefault();

--- a/src/services/tauri.ts
+++ b/src/services/tauri.ts
@@ -29,6 +29,10 @@ export async function updateWorkspaceSettings(
   return invoke<WorkspaceInfo>("update_workspace_settings", { id, settings });
 }
 
+export async function removeWorkspace(id: string): Promise<void> {
+  return invoke("remove_workspace", { id });
+}
+
 export async function connectWorkspace(id: string): Promise<void> {
   return invoke("connect_workspace", { id });
 }


### PR DESCRIPTION
This PR adds the ability to delete workspaces from CodexMonitor.

## Changes
- Added `removeWorkspace` service function in `tauri.ts` that calls the backend `remove_workspace` command
- Added `removeWorkspace` hook function in `useWorkspaces.ts` with confirmation dialog using Tauri's `ask` API
- Added workspace context menu in `Sidebar.tsx` with delete option (right-click on workspace)
- Wired up delete handler in `App.tsx`

## Features
- Right-click any workspace in the sidebar to access the context menu
- Select "Delete" to remove a workspace
- A confirmation dialog appears with "Delete" and "Cancel" buttons
- The dialog shows the workspace name and warns about removal
- Only proceeds with deletion if user confirms

## Technical Details
- Uses Tauri's native `ask` dialog for platform-native confirmation UI
- Properly cleans up workspace state and active workspace selection
- Includes debug logging for deletion events
- Follows the same pattern as thread deletion for consistency