### PR TITLE
Add window dragging permission

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    "core:window:allow-start-dragging"
   ]
 }


### PR DESCRIPTION
## Summary
- add core:window:allow-start-dragging permission to default capability
- ensure window drag requests are permitted for overlay titlebar

Resolves issue seen in logs
<img width="2408" height="1404" alt="image" src="https://github.com/user-attachments/assets/6ff8e428-e105-4858-abda-c9aad3e9f945" />

