### PR TITLE
Fix codex app-server spawn environment and init timeout

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["io-util", "process", "rt", "sync"] }
+tokio = { version = "1", features = ["io-util", "process", "rt", "sync", "time"] }
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-dialog = "2"
 git2 = "0.20.3"


### PR DESCRIPTION
## Summary\n- Strip DYLD_* environment variables when spawning the codex app-server on macOS to avoid library leakage.\n- Remove node_modules/.bin entries from PATH when using the default codex binary so npm-run wrappers don't shadow the real install.\n- Add a 5s timeout for the initialize request and extra debug logging for stdout/stderr + exit status.\n\n## Motivation\nWhen running via npm scripts, PATH prepends node_modules/.bin and can resolve an unrelated codex script, causing the app-server to exit immediately and the UI to show "request canceled". DYLD_* vars from cargo can also poison child processes.\n\n## Testing\n- Not run (local environment).