### PR TITLE
Handle workspace picker return values and surface errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -196,9 +196,21 @@ function MainApp() {
   });
 
   async function handleAddWorkspace() {
-    const workspace = await addWorkspace();
-    if (workspace) {
-      setActiveThreadId(null, workspace.id);
+    try {
+      const workspace = await addWorkspace();
+      if (workspace) {
+        setActiveThreadId(null, workspace.id);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      addDebugEntry({
+        id: `${Date.now()}-client-add-workspace-error`,
+        timestamp: Date.now(),
+        source: "error",
+        label: "workspace/add error",
+        payload: message,
+      });
+      alert(`Failed to add workspace.\n\n${message}`);
     }
   }
 

--- a/src/services/tauri.ts
+++ b/src/services/tauri.ts
@@ -5,8 +5,11 @@ import type { GitFileDiff, GitFileStatus, GitLogResponse, ReviewTarget } from ".
 
 export async function pickWorkspacePath(): Promise<string | null> {
   const selection = await open({ directory: true, multiple: false });
-  if (!selection || Array.isArray(selection)) {
+  if (!selection) {
     return null;
+  }
+  if (Array.isArray(selection)) {
+    return selection[0] ?? null;
   }
   return selection;
 }


### PR DESCRIPTION
## Summary\n- Normalize folder picker results when Tauri returns an array even with multiple=false.\n- Wrap addWorkspace in a try/catch and show a readable error while logging to the debug panel.\n\n## Motivation\nThis avoids silently ignoring valid selections and makes backend failures visible to users.\n\n## Testing\n- Not run (local environment).