### PR TITLE
Allow window dragging capability and dev remote URLs

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,9 +2,16 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
+  "remote": {
+    "urls": [
+      "http://localhost:1420/*",
+      "http://127.0.0.1:1420/*"
+    ]
+  },
   "windows": ["main", "about"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "opener:default",
     "dialog:default"
   ]


### PR DESCRIPTION
## Summary\n- Permit  in the default capability set.\n- Allow localhost/127.0.0.1 dev URLs in the capability remote allowlist.\n\n## Motivation\nEnables the drag-strip to work under Tauri v2 and keeps dev origin access explicit.\n\n## Testing\n- Not run (local environment).