### PR TITLE
Ensure Cargo is on PATH for tauri dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "PATH=$HOME/.cargo/bin:$PATH tauri"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",


### PR DESCRIPTION
## Summary\n- Prefix the tauri dev script with ~/.cargo/bin to ensure Cargo is available in npm-driven shells.\n\n## Motivation\nPrevents dev failures on machines where Cargo isn't already on PATH for npm scripts.\n\n## Testing\n- Not run (local environment).