### PR TITLE
fix(linux):  ubuntu-24.04 to fix broken title in AppImages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
+          - platform: ubuntu-24.04
             arch: x86_64
-          - platform: ubuntu-22.04-arm
+          - platform: ubuntu-24.04-arm
             arch: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
@Dimillian 
Hey I noticed this regression that appeared only in AppImages built in ci.


### Correct title (when `ubuntu-24.04` runner used)
<img width="1919" height="373" alt="Screenshot_20260115_172130" src="https://github.com/user-attachments/assets/6d514f7c-f954-4863-94af-f1a9ff29590f" />

### Incorrect title (when `ubuntu-22.04` runner used originally)
<img width="1298" height="363" alt="Screenshot_20260115_152608" src="https://github.com/user-attachments/assets/cb6cbb91-1019-4029-a775-72adaf831701" />

Incorrect one drives me nuts so I actually distilled the changes and found it really depends on the runner used while building AppImages.. Typical Linux programming experience nothing unusual :dagger: 

