### PR TITLE
Refactor App composition helpers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import "./styles/base.css";
 import "./styles/buttons.css";
 import "./styles/sidebar.css";
@@ -54,6 +53,8 @@ import { useWorkspaceRestore } from "./features/workspaces/hooks/useWorkspaceRes
 import { useResizablePanels } from "./features/layout/hooks/useResizablePanels";
 import { useLayoutMode } from "./features/layout/hooks/useLayoutMode";
 import { useSidebarToggles } from "./features/layout/hooks/useSidebarToggles";
+import { useTransparencyPreference } from "./features/layout/hooks/useTransparencyPreference";
+import { useWindowLabel } from "./features/layout/hooks/useWindowLabel";
 import {
   RightPanelCollapseButton,
   SidebarCollapseButton,
@@ -83,19 +84,6 @@ import type {
   QueuedMessage,
   WorkspaceInfo,
 } from "./types";
-
-function useWindowLabel() {
-  const [label, setLabel] = useState("main");
-  useEffect(() => {
-    try {
-      const window = getCurrentWindow();
-      setLabel(window.label ?? "main");
-    } catch {
-      setLabel("main");
-    }
-  }, []);
-  return label;
-}
 
 function MainApp() {
   const {
@@ -187,10 +175,7 @@ function MainApp() {
   const [settingsSection, setSettingsSection] = useState<SettingsSection | null>(
     null,
   );
-  const [reduceTransparency, setReduceTransparency] = useState(() => {
-    const stored = localStorage.getItem("reduceTransparency");
-    return stored === "true";
-  });
+  const { reduceTransparency, setReduceTransparency } = useTransparencyPreference();
   const dictationReady = dictationModel.status?.state === "ready";
   const holdDictationKey = (appSettings.dictationHoldKey ?? "").toLowerCase();
   const handleToggleDictation = useCallback(async () => {
@@ -308,10 +293,6 @@ function MainApp() {
       prev === "current" ? appSettings.defaultAccessMode : prev
     );
   }, [appSettings.defaultAccessMode]);
-
-  useEffect(() => {
-    localStorage.setItem("reduceTransparency", String(reduceTransparency));
-  }, [reduceTransparency]);
 
   const { status: gitStatus, refresh: refreshGitStatus } =
     useGitStatus(activeWorkspace);

--- a/src/features/layout/hooks/useTransparencyPreference.ts
+++ b/src/features/layout/hooks/useTransparencyPreference.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export function useTransparencyPreference(storageKey = "reduceTransparency") {
+  const [reduceTransparency, setReduceTransparency] = useState(() => {
+    const stored = localStorage.getItem(storageKey);
+    return stored === "true";
+  });
+
+  useEffect(() => {
+    localStorage.setItem(storageKey, String(reduceTransparency));
+  }, [reduceTransparency, storageKey]);
+
+  return {
+    reduceTransparency,
+    setReduceTransparency,
+  };
+}

--- a/src/features/layout/hooks/useWindowLabel.ts
+++ b/src/features/layout/hooks/useWindowLabel.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export function useWindowLabel(defaultLabel = "main") {
+  const [label, setLabel] = useState(defaultLabel);
+
+  useEffect(() => {
+    try {
+      const window = getCurrentWindow();
+      setLabel(window.label ?? defaultLabel);
+    } catch {
+      setLabel(defaultLabel);
+    }
+  }, [defaultLabel]);
+
+  return label;
+}


### PR DESCRIPTION
### Motivation

- Reduce imperative logic in the composition root by extracting window-label detection and localStorage-backed transparency state into dedicated hooks to improve testability and separation of concerns.

### Description

- Add `useWindowLabel` in `src/features/layout/hooks/useWindowLabel.ts` to encapsulate `getCurrentWindow()` label lookup and return a stable window label via a hook.
- Add `useTransparencyPreference` in `src/features/layout/hooks/useTransparencyPreference.ts` to encapsulate the `reduceTransparency` localStorage state and its persistence.
- Update `src/App.tsx` to import and use `useWindowLabel` and `useTransparencyPreference`, removing the inline `getCurrentWindow` logic and the manual `localStorage` effect.

### Testing

- Ran `npm run lint`, which executed but reported a TypeScript compatibility warning from `@typescript-eslint` due to the local TypeScript version; no new lint errors introduced.
- Ran `npm run typecheck`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cbd245750832592ca9721dec4835a)