### PR TITLE
fix: worktree dialog black background

### DIFF
--- a/src/styles/worktree-modal.css
+++ b/src/styles/worktree-modal.css
@@ -7,7 +7,12 @@
 .worktree-modal-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.65);
+  background: rgba(6, 8, 12, 0.55);
+  backdrop-filter: blur(8px);
+}
+
+.app.reduced-transparency .worktree-modal-backdrop {
+  backdrop-filter: none;
 }
 
 .worktree-modal-card {
@@ -16,8 +21,8 @@
   left: 50%;
   transform: translate(-50%, -50%);
   width: min(420px, calc(100vw - 48px));
-  background: rgba(8, 10, 16, 0.96);
-  border: 1px solid var(--border-subtle);
+  background: var(--surface-card-strong);
+  border: 1px solid var(--border-stronger);
   border-radius: 16px;
   padding: 18px 20px;
   display: flex;


### PR DESCRIPTION
Problem: Worktree dialog renders black due to hard-coded dark RGBA surfaces.
Solution: Use theme surface variables and add a blurred, reduced-transparency-aware backdrop.

Before change:
<img width="1774" height="1102" alt="image" src="https://github.com/user-attachments/assets/656853e1-16ba-4d0a-88e4-05f7262b508d" />

After fix:
<img width="1608" height="908" alt="image" src="https://github.com/user-attachments/assets/f8b60958-8731-4a6a-a4ab-72ea2ce88d22" />
