### PR TITLE
Add menu item to check for updates and show up-to-date toast

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use tauri::menu::{Menu, MenuItemBuilder, PredefinedMenuItem, Submenu};
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 mod backend;
 mod codex;
@@ -42,12 +42,16 @@ pub fn run() {
             let app_name = handle.package_info().name.clone();
             let about_item = MenuItemBuilder::with_id("about", format!("About {app_name}"))
                 .build(handle)?;
+            let check_updates_item =
+                MenuItemBuilder::with_id("check_for_updates", "Check for Updates...")
+                    .build(handle)?;
             let app_menu = Submenu::with_items(
                 handle,
                 app_name.clone(),
                 true,
                 &[
                     &about_item,
+                    &check_updates_item,
                     &PredefinedMenuItem::separator(handle)?,
                     &PredefinedMenuItem::services(handle, None)?,
                     &PredefinedMenuItem::separator(handle)?,
@@ -185,6 +189,9 @@ pub fn run() {
                     .inner_size(360.0, 240.0)
                     .center()
                     .build();
+                }
+                "check_for_updates" => {
+                    let _ = app.emit("updater-check", ());
                 }
                 "file_close_window" | "window_close" => {
                     if let Some(window) = app.get_webview_window("main") {

--- a/src/features/update/components/UpdateToast.test.tsx
+++ b/src/features/update/components/UpdateToast.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { UpdateState } from "../hooks/useUpdater";
 import { UpdateToast } from "./UpdateToast";
@@ -65,5 +65,19 @@ describe("UpdateToast", () => {
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders latest state and allows dismiss", () => {
+    const onDismiss = vi.fn();
+    const state: UpdateState = { stage: "latest" };
+
+    const { container } = render(
+      <UpdateToast state={state} onUpdate={vi.fn()} onDismiss={onDismiss} />,
+    );
+    const scoped = within(container);
+
+    expect(scoped.getByText("You’re up to date.")).toBeTruthy();
+    fireEvent.click(scoped.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/update/components/UpdateToast.tsx
+++ b/src/features/update/components/UpdateToast.tsx
@@ -59,6 +59,16 @@ export function UpdateToast({ state, onUpdate, onDismiss }: UpdateToastProps) {
             </div>
           </>
         )}
+        {state.stage === "latest" && (
+          <div className="update-toast-inline">
+            <div className="update-toast-body update-toast-body-inline">
+              You’re up to date.
+            </div>
+            <button className="secondary" onClick={onDismiss}>
+              Dismiss
+            </button>
+          </div>
+        )}
         {state.stage === "downloading" && (
           <>
             <div className="update-toast-body">

--- a/src/features/update/hooks/useUpdater.test.ts
+++ b/src/features/update/hooks/useUpdater.test.ts
@@ -63,6 +63,24 @@ describe("useUpdater", () => {
     expect(result.current.state.stage).toBe("idle");
   });
 
+  it("announces when no update is available for manual checks", async () => {
+    vi.useFakeTimers();
+    checkMock.mockResolvedValue(null);
+    const { result } = renderHook(() => useUpdater({}));
+
+    await act(async () => {
+      await result.current.checkForUpdates({ announceNoUpdate: true });
+    });
+
+    expect(result.current.state.stage).toBe("latest");
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.state.stage).toBe("idle");
+  });
+
   it("downloads and restarts when update is available", async () => {
     const close = vi.fn();
     const downloadAndInstall = vi.fn(async (onEvent) => {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -40,3 +40,11 @@ export async function subscribeTerminalOutput(
     onEvent(event.payload);
   });
 }
+
+export async function subscribeUpdaterCheck(
+  onEvent: () => void,
+): Promise<Unsubscribe> {
+  return listen("updater-check", () => {
+    onEvent();
+  });
+}

--- a/src/styles/update-toasts.css
+++ b/src/styles/update-toasts.css
@@ -92,6 +92,17 @@
   justify-content: flex-end;
 }
 
+.update-toast-inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.update-toast-body-inline {
+  margin-bottom: 0;
+}
+
 @keyframes update-toast-in {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
Fixes #133 
- Add a “Check for Updates…” menu item in the app menu and wire it to the updater.
- Show a “You’re up to date.” toast only when a manual check finds no update (auto-dismiss after 2s).

## Evidence
<img width="354" height="228" alt="image" src="https://github.com/user-attachments/assets/d6d8372a-107b-4dde-962e-a5a64bfb9e84" />
<img width="415" height="136" alt="image" src="https://github.com/user-attachments/assets/5817cdd7-f00b-413f-8652-4f228f0f93e0" />
<img width="368" height="123" alt="image" src="https://github.com/user-attachments/assets/2b781201-038e-4fe4-ba8f-bdf80ff9bb04" />

## Testing
- Manual
