### PR TITLE
Fix thread resume merge dropping repeated user messages

### DIFF
--- a/src/utils/threadItems.test.ts
+++ b/src/utils/threadItems.test.ts
@@ -173,4 +173,43 @@ describe("threadItems", () => {
       text: "Hello",
     });
   });
+
+  it("keeps later optimistic duplicates when the matching remote item is already local", () => {
+    const remote: ConversationItem[] = [
+      {
+        id: "remote-1",
+        kind: "message",
+        role: "user",
+        text: "Hello",
+      },
+    ];
+    const local: ConversationItem[] = [
+      {
+        id: "remote-1",
+        kind: "message",
+        role: "user",
+        text: "Hello",
+      },
+      {
+        id: "9999-user",
+        kind: "message",
+        role: "user",
+        text: "Hello",
+      },
+    ];
+    const merged = mergeThreadItems(remote, local);
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({
+      id: "remote-1",
+      kind: "message",
+      role: "user",
+      text: "Hello",
+    });
+    expect(merged[1]).toMatchObject({
+      id: "9999-user",
+      kind: "message",
+      role: "user",
+      text: "Hello",
+    });
+  });
 });

--- a/src/utils/threadItems.ts
+++ b/src/utils/threadItems.ts
@@ -445,8 +445,12 @@ export function mergeThreadItems(
     return remoteItems;
   }
   const byId = new Map(remoteItems.map((item) => [item.id, item]));
+  const localIds = new Set(localItems.map((item) => item.id));
   const remoteMessageCounts = new Map<string, number>();
   remoteItems.forEach((item) => {
+    if (localIds.has(item.id)) {
+      return;
+    }
     const key = messageDedupKey(item);
     if (!key) {
       return;


### PR DESCRIPTION
## Summary
- avoid counting remote items that already exist locally when deduping optimistic messages
- add a regression test for repeated user messages with identical text

## Problem
When switching threads, `thread/resume` merges remote items with local optimistic messages. If a user sends the same text twice, the merge can drop the later message because the remote list already contains the earlier one. This makes a previously sent user message disappear after a few tab switches.

## Testing
- npm run lint
- npm run test
- npm run typecheck