### PR TITLE
Set Sentry release from app version

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ const sentryDsn =
 Sentry.init({
   dsn: sentryDsn,
   enabled: Boolean(sentryDsn),
+  release: __APP_VERSION__,
 });
 
 Sentry.metrics.count("app_open", 1, {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,24 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+) as {
+  version: string;
+};
+
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
   worker: {
     format: "es",
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version),
   },
   test: {
     environment: "node",


### PR DESCRIPTION
### Motivation
- Sentry was initialized without a release tag, making it hard to correlate errors with app versions.
- The app version is available in `package.json` and should be injected into the client build so Sentry receives a correct `release` value.

### Description
- Read `version` from `package.json` in `vite.config.ts` and expose it as a Vite define `__APP_VERSION__`.
- Pass `__APP_VERSION__` into `Sentry.init` as the `release` in `src/main.tsx` so Sentry events are attributed to the app version.
- Add a global type declaration for `__APP_VERSION__` in `src/vite-env.d.ts`.

### Testing
- Ran `npm run lint`, which completed successfully but reported one existing warning about a duplicate Hook dependency; lint did not fail.
- Ran `npm run typecheck` (`tsc --noEmit`) which completed with no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971454efe108325835e2c80eeac69fe)