### PR TITLE
Add transparency modes (glass/blur/reduced) and fix re-enabling Liquid Glass

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,8 +115,9 @@ function MainApp() {
     setAppSettings,
     doctor,
     appSettingsLoading,
-    reduceTransparency,
-    setReduceTransparency,
+    transparencyMode,
+    setTransparencyMode,
+    transparencyModes,
     uiScale,
     scaleShortcutTitle,
     scaleShortcutText,
@@ -144,7 +145,7 @@ function MainApp() {
     handleCopyDebug,
     clearDebugEntries,
   } = useDebugLog();
-  useLiquidGlassEffect({ reduceTransparency, onDebug: addDebugEntry });
+  useLiquidGlassEffect({ transparencyMode, onDebug: addDebugEntry });
   const [accessMode, setAccessMode] = useState<AccessMode>("current");
   const [activeTab, setActiveTab] = useState<
     "projects" | "codex" | "git" | "log"
@@ -1275,7 +1276,7 @@ function MainApp() {
   const appClassName = `app ${isCompact ? "layout-compact" : "layout-desktop"}${
     isPhone ? " layout-phone" : ""
   }${isTablet ? " layout-tablet" : ""}${
-    reduceTransparency ? " reduced-transparency" : ""
+    transparencyMode === "reduced" ? " reduced-transparency" : ""
   }${!isCompact && sidebarCollapsed ? " sidebar-collapsed" : ""}${
     !isCompact && rightPanelCollapsed ? " right-panel-collapsed" : ""
   }${isDefaultScale ? " ui-scale-default" : ""}`;
@@ -1748,8 +1749,9 @@ function MainApp() {
           onMoveWorkspaceGroup: moveWorkspaceGroup,
           onDeleteWorkspaceGroup: deleteWorkspaceGroup,
           onAssignWorkspaceGroup: assignWorkspaceGroup,
-          reduceTransparency,
-          onToggleTransparency: setReduceTransparency,
+          transparencyMode,
+          transparencyModes,
+          onTransparencyModeChange: setTransparencyMode,
           appSettings,
           onUpdateAppSettings: async (next) => {
             await queueSaveSettings(next);

--- a/src/features/app/hooks/useAppSettingsController.ts
+++ b/src/features/app/hooks/useAppSettingsController.ts
@@ -13,8 +13,11 @@ export function useAppSettingsController() {
   } = useAppSettings();
 
   useThemePreference(appSettings.theme);
-  const { reduceTransparency, setReduceTransparency } =
-    useTransparencyPreference();
+  const {
+    transparencyMode,
+    setTransparencyMode,
+    availableModes: transparencyModes,
+  } = useTransparencyPreference();
 
   const {
     uiScale,
@@ -34,8 +37,9 @@ export function useAppSettingsController() {
     queueSaveSettings,
     doctor,
     appSettingsLoading,
-    reduceTransparency,
-    setReduceTransparency,
+    transparencyMode,
+    setTransparencyMode,
+    transparencyModes,
     uiScale,
     scaleShortcutTitle,
     scaleShortcutText,

--- a/src/features/layout/hooks/useTransparencyPreference.ts
+++ b/src/features/layout/hooks/useTransparencyPreference.ts
@@ -1,17 +1,80 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { isGlassSupported } from "tauri-plugin-liquid-glass-api";
+import type { TransparencyMode } from "../../../types";
 
-export function useTransparencyPreference(storageKey = "reduceTransparency") {
-  const [reduceTransparency, setReduceTransparency] = useState(() => {
-    const stored = localStorage.getItem(storageKey);
-    return stored === "true";
-  });
+const STORAGE_KEY = "transparencyMode";
+const LEGACY_STORAGE_KEY = "reduceTransparency";
+
+const isTransparencyMode = (value: string | null): value is TransparencyMode =>
+  value === "glass" || value === "blur" || value === "reduced";
+
+const readStoredTransparency = () => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (isTransparencyMode(stored)) {
+    return { mode: stored, hasStoredPreference: true };
+  }
+  const legacyStored = localStorage.getItem(LEGACY_STORAGE_KEY);
+  if (legacyStored === "true") {
+    return { mode: "reduced" as TransparencyMode, hasStoredPreference: true };
+  }
+  return { mode: "blur" as TransparencyMode, hasStoredPreference: false };
+};
+
+export function useTransparencyPreference() {
+  const [{ mode, hasStoredPreference }, setPreferenceState] = useState(() =>
+    readStoredTransparency(),
+  );
+  const [glassSupported, setGlassSupported] = useState<boolean | null>(null);
 
   useEffect(() => {
-    localStorage.setItem(storageKey, String(reduceTransparency));
-  }, [reduceTransparency, storageKey]);
+    localStorage.setItem(STORAGE_KEY, mode);
+  }, [mode]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkSupport = async () => {
+      try {
+        const supported = await isGlassSupported();
+        if (cancelled) {
+          return;
+        }
+        setGlassSupported(supported);
+        if (!supported && mode === "glass") {
+          setPreferenceState({ mode: "blur", hasStoredPreference });
+        }
+        if (!hasStoredPreference && supported && mode !== "glass") {
+          setPreferenceState({ mode: "glass", hasStoredPreference: false });
+        }
+      } catch {
+        if (!cancelled) {
+          setGlassSupported(false);
+        }
+      }
+    };
+
+    void checkSupport();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasStoredPreference, mode]);
+
+  const setTransparencyMode = useCallback((next: TransparencyMode) => {
+    setPreferenceState({ mode: next, hasStoredPreference: true });
+  }, []);
+
+  const availableModes = useMemo<TransparencyMode[]>(() => {
+    if (glassSupported) {
+      return ["glass", "blur", "reduced"];
+    }
+    return ["blur", "reduced"];
+  }, [glassSupported]);
 
   return {
-    reduceTransparency,
-    setReduceTransparency,
+    transparencyMode: mode,
+    setTransparencyMode,
+    availableModes,
+    glassSupported,
   };
 }

--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -81,18 +81,21 @@ const createDoctorResult = () => ({
 const renderDisplaySection = (
   options: {
     appSettings?: Partial<AppSettings>;
-    reduceTransparency?: boolean;
+    transparencyMode?: ComponentProps<typeof SettingsView>["transparencyMode"];
+    transparencyModes?: ComponentProps<typeof SettingsView>["transparencyModes"];
     onUpdateAppSettings?: ComponentProps<typeof SettingsView>["onUpdateAppSettings"];
-    onToggleTransparency?: ComponentProps<typeof SettingsView>["onToggleTransparency"];
+    onTransparencyModeChange?: ComponentProps<typeof SettingsView>["onTransparencyModeChange"];
   } = {},
 ) => {
   cleanup();
   const onUpdateAppSettings =
     options.onUpdateAppSettings ?? vi.fn().mockResolvedValue(undefined);
-  const onToggleTransparency = options.onToggleTransparency ?? vi.fn();
+  const onTransparencyModeChange =
+    options.onTransparencyModeChange ?? vi.fn();
   const props: ComponentProps<typeof SettingsView> = {
-    reduceTransparency: options.reduceTransparency ?? false,
-    onToggleTransparency,
+    transparencyMode: options.transparencyMode ?? "blur",
+    transparencyModes: options.transparencyModes ?? ["blur", "reduced"],
+    onTransparencyModeChange,
     appSettings: { ...baseSettings, ...options.appSettings },
     onUpdateAppSettings,
     workspaceGroups: [],
@@ -120,7 +123,7 @@ const renderDisplaySection = (
   render(<SettingsView {...props} />);
   fireEvent.click(screen.getByRole("button", { name: "Display & Sound" }));
 
-  return { onUpdateAppSettings, onToggleTransparency };
+  return { onUpdateAppSettings, onTransparencyModeChange };
 };
 
 describe("SettingsView Display", () => {
@@ -138,19 +141,23 @@ describe("SettingsView Display", () => {
     });
   });
 
-  it("toggles reduce transparency", () => {
-    const onToggleTransparency = vi.fn();
-    renderDisplaySection({ onToggleTransparency, reduceTransparency: false });
+  it("updates transparency mode", () => {
+    const onTransparencyModeChange = vi.fn();
+    renderDisplaySection({
+      onTransparencyModeChange,
+      transparencyMode: "blur",
+      transparencyModes: ["blur", "reduced"],
+    });
 
     const row = screen
-      .getByText("Reduce transparency")
+      .getByText("Transparency")
       .closest(".settings-toggle-row") as HTMLElement | null;
     if (!row) {
-      throw new Error("Expected reduce transparency row");
+      throw new Error("Expected transparency row");
     }
-    fireEvent.click(within(row).getByRole("button"));
+    fireEvent.click(within(row).getByRole("radio", { name: "Reduced" }));
 
-    expect(onToggleTransparency).toHaveBeenCalledWith(true);
+    expect(onTransparencyModeChange).toHaveBeenCalledWith("reduced");
   });
 
   it("commits interface scale on blur and enter with clamping", async () => {
@@ -280,8 +287,9 @@ describe("SettingsView Shortcuts", () => {
         onMoveWorkspaceGroup={vi.fn().mockResolvedValue(null)}
         onDeleteWorkspaceGroup={vi.fn().mockResolvedValue(null)}
         onAssignWorkspaceGroup={vi.fn().mockResolvedValue(null)}
-        reduceTransparency={false}
-        onToggleTransparency={vi.fn()}
+        transparencyMode="blur"
+        transparencyModes={["blur", "reduced"]}
+        onTransparencyModeChange={vi.fn()}
         appSettings={baseSettings}
         onUpdateAppSettings={vi.fn().mockResolvedValue(undefined)}
         onRunDoctor={vi.fn().mockResolvedValue(createDoctorResult())}
@@ -318,8 +326,9 @@ describe("SettingsView Shortcuts", () => {
         onMoveWorkspaceGroup={vi.fn().mockResolvedValue(null)}
         onDeleteWorkspaceGroup={vi.fn().mockResolvedValue(null)}
         onAssignWorkspaceGroup={vi.fn().mockResolvedValue(null)}
-        reduceTransparency={false}
-        onToggleTransparency={vi.fn()}
+        transparencyMode="blur"
+        transparencyModes={["blur", "reduced"]}
+        onTransparencyModeChange={vi.fn()}
         appSettings={baseSettings}
         onUpdateAppSettings={vi.fn().mockResolvedValue(undefined)}
         onRunDoctor={vi.fn().mockResolvedValue(createDoctorResult())}

--- a/src/features/settings/components/SettingsView.tsx
+++ b/src/features/settings/components/SettingsView.tsx
@@ -16,6 +16,7 @@ import type {
   AppSettings,
   CodexDoctorResult,
   DictationModelStatus,
+  TransparencyMode,
   WorkspaceGroup,
   WorkspaceInfo,
 } from "../../../types";
@@ -112,8 +113,9 @@ export type SettingsViewProps = {
     workspaceId: string,
     groupId: string | null,
   ) => Promise<boolean | null>;
-  reduceTransparency: boolean;
-  onToggleTransparency: (value: boolean) => void;
+  transparencyMode: TransparencyMode;
+  transparencyModes: TransparencyMode[];
+  onTransparencyModeChange: (value: TransparencyMode) => void;
   appSettings: AppSettings;
   onUpdateAppSettings: (next: AppSettings) => Promise<void>;
   onRunDoctor: (codexBin: string | null) => Promise<CodexDoctorResult>;
@@ -190,8 +192,9 @@ export function SettingsView({
   onMoveWorkspaceGroup,
   onDeleteWorkspaceGroup,
   onAssignWorkspaceGroup,
-  reduceTransparency,
-  onToggleTransparency,
+  transparencyMode,
+  transparencyModes,
+  onTransparencyModeChange,
   appSettings,
   onUpdateAppSettings,
   onRunDoctor,
@@ -251,6 +254,14 @@ export function SettingsView({
       ) ?? DICTATION_MODELS[1]
     );
   }, [appSettings.dictationModelId]);
+  const transparencyLabels: Record<TransparencyMode, string> = {
+    glass: "Glass",
+    blur: "Blur",
+    reduced: "Reduced",
+  };
+  const transparencySubtitle = transparencyModes.includes("glass")
+    ? "Choose glass, blur, or reduced surfaces."
+    : "Choose blur or reduced surfaces.";
 
   const projects = useMemo(
     () => groupedWorkspaces.flatMap((group) => group.workspaces),
@@ -978,19 +989,31 @@ export function SettingsView({
                 </div>
                 <div className="settings-toggle-row">
                   <div>
-                    <div className="settings-toggle-title">Reduce transparency</div>
+                    <div className="settings-toggle-title">Transparency</div>
                     <div className="settings-toggle-subtitle">
-                      Use solid surfaces instead of glass.
+                      {transparencySubtitle}
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    className={`settings-toggle ${reduceTransparency ? "on" : ""}`}
-                    onClick={() => onToggleTransparency(!reduceTransparency)}
-                    aria-pressed={reduceTransparency}
+                  <div
+                    className="settings-segmented"
+                    role="radiogroup"
+                    aria-label="Transparency"
                   >
-                    <span className="settings-toggle-knob" />
-                  </button>
+                    {transparencyModes.map((mode) => (
+                      <button
+                        key={mode}
+                        type="button"
+                        className={`settings-segmented-button ${
+                          transparencyMode === mode ? "active" : ""
+                        }`}
+                        onClick={() => onTransparencyModeChange(mode)}
+                        role="radio"
+                        aria-checked={transparencyMode === mode}
+                      >
+                        {transparencyLabels[mode]}
+                      </button>
+                    ))}
+                  </div>
                 </div>
                 <div className="settings-toggle-row settings-scale-row">
                   <div>

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -550,6 +550,39 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
+.settings-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 999px;
+  background: var(--surface-control);
+  border: 1px solid var(--border-muted);
+}
+
+.settings-segmented-button {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-subtle);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.settings-segmented-button.active {
+  background: var(--surface-card-strong);
+  color: var(--text-strong);
+  border-color: var(--border-strong);
+}
+
+.app.reduced-transparency .settings-segmented {
+  background: var(--surface-control-hover);
+  border-color: var(--border-stronger);
+}
+
 @media (max-width: 720px) {
   .settings-body {
     grid-template-columns: 1fr;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export type ReviewTarget =
 export type AccessMode = "read-only" | "current" | "full-access";
 export type BackendMode = "local" | "remote";
 export type ThemePreference = "system" | "light" | "dark";
+export type TransparencyMode = "glass" | "blur" | "reduced";
 
 
 export type ComposerEditorPreset = "default" | "helpful" | "smart";


### PR DESCRIPTION
### Motivation
- Restore reliable switching between blur and glass by reintroducing the explicit `enabled: true` when applying Liquid Glass and replacing the binary `reduceTransparency` flag with a three-value `TransparencyMode` to express `glass`, `blur`, or `reduced` behaviors. 
- Detect runtime glass support and migrate legacy settings so the UI exposes only the appropriate transparency choices and defaults sensibly for new and existing users.

### Description
- Reintroduced `enabled: true` in `src/features/app/hooks/useLiquidGlassEffect.ts` when applying the `glass` mode and added logic to disable the effect when the mode is not `glass`, while updating the hook to accept `transparencyMode` instead of a boolean. 
- Replaced `useTransparencyPreference` with a richer implementation in `src/features/layout/hooks/useTransparencyPreference.ts` that persists `transparencyMode` (migrates from `reduceTransparency`), checks `isGlassSupported`, exposes `availableModes`, and provides `setTransparencyMode`. 
- Wired the new API through the app by updating `useAppSettingsController.ts` and `App.tsx` to use `transparencyMode`, `setTransparencyMode`, and `transparencyModes` instead of `reduceTransparency`. 
- Updated `SettingsView.tsx`, `SettingsView.test.tsx`, `src/styles/settings.css`, and `src/types.ts` to add the segmented radiogroup UI for transparency modes, associated styles, test adjustments, and the `TransparencyMode` type.

### Testing
- No automated tests were executed for this change; existing tests in `SettingsView.test.tsx` were updated to match the new `transparencyMode` API but were not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697284fd08508325947c3c48df754d41)