### PR TITLE
fix: settings backdrop blur on macOS 15

### DIFF
--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -13,6 +13,7 @@
   inset: 0;
   background: rgba(6, 8, 12, 0.55);
   backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .settings-window {
@@ -41,6 +42,7 @@
 
 .app.reduced-transparency .settings-backdrop {
   backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .app.reduced-transparency .settings-titlebar {


### PR DESCRIPTION
### Motivation
- Some macOS WebKit builds (notably macOS 15) do not apply the unprefixed `backdrop-filter` reliably, causing a transparency/blur glitch in the settings modal backdrop.

### Description
- Add the WebKit-prefixed `-webkit-backdrop-filter: blur(8px);` to `.settings-backdrop` and clear it in the `.app.reduced-transparency .settings-backdrop` rule to ensure consistent blur behavior across WebKit implementations (`src/styles/settings.css`).

### Testing
- Ran `npm run lint`, `npm run test` (175 tests across 39 files — all passed), and `npm run typecheck`, and all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b3e11ff0832585b594a1a8d49928)