### PR TITLE
fix: add macOS microphone entitlement for dictation

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,6 +47,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
+      "entitlements": "Entitlements.plist",
       "infoPlist": "Info.plist"
     }
   },


### PR DESCRIPTION
## Summary
  - add macOS entitlements file to allow audio input
  - wire entitlements into Tauri bundle config

  ## Context
  macOS TCC won’t prompt for microphone without `com.apple.security.device.audio-input` entitlement under
  hardened runtime.