### PR TITLE
fix(linux/nvidia): replace env var with __NV_PRIME_RENDER_OFFLOAD=1

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,8 +2,8 @@ use tauri::Manager;
 
 mod backend;
 mod codex;
-mod codex_home;
 mod codex_config;
+mod codex_home;
 #[cfg(not(target_os = "windows"))]
 #[path = "dictation.rs"]
 mod dictation;
@@ -20,20 +20,20 @@ mod remote_backend;
 mod rules;
 mod settings;
 mod state;
-mod terminal;
-mod window;
 mod storage;
+mod terminal;
 mod types;
 mod utils;
+mod window;
 mod workspaces;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(target_os = "linux")]
     {
-        // Avoid WebKit compositing issues on some Linux setups (GBM buffer errors).
-        if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
-            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        // Avoid WebKit compositing issues on NVIDIA Linux setups (GBM buffer errors).
+        if std::env::var_os("__NV_PRIME_RENDER_OFFLOAD").is_none() {
+            std::env::set_var("__NV_PRIME_RENDER_OFFLOAD", "1");
         }
     }
 


### PR DESCRIPTION
Hey I have added Linux support initially and it's a well known issue with NVIDIA cards and Tauri Apps that the app starts but the screen is blank. My original fix was to force `WEBKIT_DISABLE_COMPOSITING_MODE=1` on Linux but this is too wide and actually just disables hardware acceleration, the app became more heavy lately and it causes problems.

I've replaced with `__NV_PRIME_RENDER_OFFLOAD=1` which targets the issue with NVIDIA setup specifically and it works well as a workaround (I have RTX 4090). This obviously needs more feedback from other Linux users, but if you don't have NVIDIA card, you should be fine.

This is better than disabling  hardware acceleration for the whole app on Linux!


## Sources

* https://github.com/QubesOS/qubes-issues/issues/9595
* https://forums.developer.nvidia.com/t/gtk-webkit-not-rendering-on-nvidia-jetpack-5-1-2-b104/296034/15
* https://forums.developer.nvidia.com/t/webkit-tauri-application-white-screen-on-dgx-spark-gpupermission-issues/348741
* https://www.reddit.com/r/rust/comments/16tzu8w/tauri_issue/ _<- (here is the workaround with offload)_

