### PR TITLE
fix: restore platform default for stop shortcut

### DIFF
--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -157,7 +157,7 @@ export function isMacPlatform(): boolean {
 }
 
 export function getDefaultInterruptShortcut(): string {
-  return "ctrl+shift+c";
+  return isMacPlatform() ? "ctrl+c" : "ctrl+shift+c";
 }
 
 export function toMenuAccelerator(value: string | null | undefined): string | null {


### PR DESCRIPTION
## Summary
- restore platform-specific default for stop shortcut (Ctrl+C on macOS, Ctrl+Shift+C elsewhere)

## Testing
- npm run lint
- npm run test
- npm run typecheck