### PR TITLE
fix: remove progress bar transition

### DIFF
--- a/src/styles/update-toasts.css
+++ b/src/styles/update-toasts.css
@@ -63,7 +63,6 @@
   display: block;
   height: 100%;
   background: linear-gradient(90deg, #4fb8ff, #3be082);
-  transition: width 0.2s ease;
 }
 
 .update-toast-progress-meta {


### PR DESCRIPTION
## Summary
- remove the progress bar transition that prevented the fill from reaching its target during rapid updates

## Testing
- not run (UI-only change)

## Human Input (lol)
I noticed over a lot of app updates that the progress bar of the download never fills up. Codex and Claude Code were never able to fix this by themselves (and trust me, I gave them >10 attempts), until I noticed that probably the animation was the culprit. And it was. Kind of sad that no tool really got this without my input. 😄