### PR TITLE
fix: testimonials copy typos on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -244,8 +244,8 @@
       <section id="testimonies" class="section">
         <div class="container">
           <div class="section-title">
-            <h2>Testimonites</h2>
-            <p>Live feedbacks</p>
+            <h2>Testimonials</h2>
+            <p>Live feedback</p>
           </div>
 
           <div class="testimonies-grid">
@@ -418,7 +418,7 @@
           <a href="#features">Features</a>
           <a href="#screens">Screenshots</a>
           <a href="#workflow">Workflow</a>
-          <a href="#testimonies">Testimonies</a>
+          <a href="#testimonies">Testimonials</a>
           <a href="changelog.html">Changelog</a>
           <a href="https://github.com/Dimillian/CodexMonitor" target="_blank" rel="noreferrer">GitHub</a>
         </div>


### PR DESCRIPTION
## Summary
- Fix typos in testimonials heading/subhead and footer link.

## Testing
- Not run (static HTML copy changes only).