### PR TITLE
fix: Validate Open in entries before selection

### DIFF
--- a/src/features/settings/components/SettingsView.tsx
+++ b/src/features/settings/components/SettingsView.tsx
@@ -243,6 +243,34 @@ const buildOpenAppDrafts = (targets: OpenAppTarget[]): OpenAppDraft[] =>
     argsText: target.args.join(" "),
   }));
 
+const isOpenAppLabelValid = (label: string) => label.trim().length > 0;
+
+const isOpenAppDraftComplete = (draft: OpenAppDraft) => {
+  if (!isOpenAppLabelValid(draft.label)) {
+    return false;
+  }
+  if (draft.kind === "app") {
+    return Boolean(draft.appName?.trim());
+  }
+  if (draft.kind === "command") {
+    return Boolean(draft.command?.trim());
+  }
+  return true;
+};
+
+const isOpenAppTargetComplete = (target: OpenAppTarget) => {
+  if (!isOpenAppLabelValid(target.label)) {
+    return false;
+  }
+  if (target.kind === "app") {
+    return Boolean(target.appName?.trim());
+  }
+  if (target.kind === "command") {
+    return Boolean(target.command?.trim());
+  }
+  return true;
+};
+
 const createOpenAppId = () => {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
@@ -702,8 +730,13 @@ export function SettingsView({
   const handleCommitOpenApps = useCallback(
     async (drafts: OpenAppDraft[], selectedId = openAppSelectedId) => {
       const nextTargets = normalizeOpenAppTargets(drafts);
+      const resolvedSelectedId = nextTargets.find(
+        (target) => target.id === selectedId && isOpenAppTargetComplete(target),
+      )?.id;
+      const firstCompleteId = nextTargets.find(isOpenAppTargetComplete)?.id;
       const nextSelectedId =
-        nextTargets.find((target) => target.id === selectedId)?.id ??
+        resolvedSelectedId ??
+        firstCompleteId ??
         nextTargets[0]?.id ??
         DEFAULT_OPEN_APP_ID;
       setOpenAppDrafts(buildOpenAppDrafts(nextTargets));
@@ -796,6 +829,10 @@ export function SettingsView({
   };
 
   const handleSelectOpenAppDefault = (id: string) => {
+    const selectedTarget = openAppDrafts.find((target) => target.id === id);
+    if (selectedTarget && !isOpenAppDraftComplete(selectedTarget)) {
+      return;
+    }
     setOpenAppSelectedId(id);
     if (typeof window !== "undefined") {
       window.localStorage.setItem(OPEN_APP_STORAGE_KEY, id);
@@ -2401,8 +2438,26 @@ export function SettingsView({
                       getKnownOpenAppIcon(target.id) ??
                       openAppIconById[target.id] ??
                       GENERIC_APP_ICON;
+                    const labelValid = isOpenAppLabelValid(target.label);
+                    const appNameValid =
+                      target.kind !== "app" || Boolean(target.appName?.trim());
+                    const commandValid =
+                      target.kind !== "command" || Boolean(target.command?.trim());
+                    const isComplete = labelValid && appNameValid && commandValid;
+                    const incompleteHint = !labelValid
+                      ? "Label required"
+                      : target.kind === "app"
+                        ? "App name required"
+                        : target.kind === "command"
+                          ? "Command required"
+                          : "Complete required fields";
                     return (
-                      <div key={target.id} className="settings-open-app-row">
+                      <div
+                        key={target.id}
+                        className={`settings-open-app-row${
+                          isComplete ? "" : " is-incomplete"
+                        }`}
+                      >
                         <div className="settings-open-app-icon-wrap" aria-hidden>
                           <img
                             className="settings-open-app-icon"
@@ -2428,6 +2483,7 @@ export function SettingsView({
                                 void handleCommitOpenApps(openAppDrafts);
                               }}
                               aria-label={`Open app label ${index + 1}`}
+                              data-invalid={!labelValid || undefined}
                             />
                           </label>
                           <label className="settings-open-app-field settings-open-app-field--type">
@@ -2464,6 +2520,7 @@ export function SettingsView({
                                   void handleCommitOpenApps(openAppDrafts);
                                 }}
                                 aria-label={`Open app name ${index + 1}`}
+                                data-invalid={!appNameValid || undefined}
                               />
                             </label>
                           )}
@@ -2483,6 +2540,7 @@ export function SettingsView({
                                   void handleCommitOpenApps(openAppDrafts);
                                 }}
                                 aria-label={`Open app command ${index + 1}`}
+                                data-invalid={!commandValid || undefined}
                               />
                             </label>
                           )}
@@ -2507,12 +2565,22 @@ export function SettingsView({
                           )}
                         </div>
                         <div className="settings-open-app-actions">
+                          {!isComplete && (
+                            <span
+                              className="settings-open-app-status"
+                              title={incompleteHint}
+                              aria-label={incompleteHint}
+                            >
+                              Incomplete
+                            </span>
+                          )}
                           <label className="settings-open-app-default">
                             <input
                               type="radio"
                               name="open-app-default"
                               checked={target.id === openAppSelectedId}
                               onChange={() => handleSelectOpenAppDefault(target.id)}
+                              disabled={!isComplete}
                             />
                             Default
                           </label>

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -494,6 +494,10 @@
   flex-wrap: wrap;
 }
 
+.settings-open-app-row.is-incomplete {
+  border-color: color-mix(in srgb, var(--status-error) 45%, var(--border-muted));
+}
+
 .settings-open-app-icon-wrap {
   flex: 0 0 auto;
   width: 24px;
@@ -533,6 +537,20 @@
   gap: 6px;
   margin-left: auto;
   flex: 0 0 auto;
+}
+
+.settings-open-app-status {
+  font-size: 11px;
+  color: var(--status-error);
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--status-error) 40%, transparent);
+  background: color-mix(in srgb, var(--status-error) 12%, transparent);
+}
+
+.settings-open-app-input[data-invalid] {
+  border-color: color-mix(in srgb, var(--status-error) 60%, var(--border-muted));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--status-error) 25%, transparent);
 }
 
 .settings-open-app-default {


### PR DESCRIPTION
## Summary
- Add validation for incomplete Open in entries in Settings and Open menus
- Disable default selection/opening when required fields are missing
- Show inline incomplete badges and input error styling

## Testing
- npm run lint
- npm run test
- npm run typecheck