### PR TITLE
fix: libgit2 branch checkout to avoid half-switched HEAD

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -8,8 +8,8 @@ use tauri::State;
 
 use crate::shared::process_core::tokio_command;
 use crate::git_utils::{
-    checkout_branch, commit_to_entry, diff_patch_to_string, diff_stats_for_path,
-    image_mime_type, list_git_roots as scan_git_roots, parse_github_repo, resolve_git_root,
+    checkout_branch, commit_to_entry, diff_patch_to_string, diff_stats_for_path, image_mime_type,
+    list_git_roots as scan_git_roots, parse_github_repo, resolve_git_root,
 };
 use crate::state::AppState;
 use crate::types::{
@@ -1497,6 +1497,7 @@ pub(crate) async fn create_git_branch(
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::Path;
 
     fn create_temp_repo() -> (PathBuf, Repository) {
         let root = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Problem

When `checkout_branch` encountered an error (e.g., dirty working tree conflicts or missing target branch), the repository could be left in an inconsistent state with HEAD pointing to a branch that was never actually checked out.

This happened because the previous implementation called `set_head()` **before** `checkout_head()`. If the checkout failed, HEAD was already updated, leaving the repo in a half-switched state.

## Solution

Reorder the libgit2 operations:
1. **Resolve the target ref first** — validate the branch exists via `revparse_single()`
2. **Checkout the tree** — use `checkout_tree()` to switch the working directory
3. **Update HEAD last** — only call `set_head()` after a successful checkout

This ensures HEAD is never updated unless the checkout succeeds, making the operation atomic from the user's perspective.

## How to Reproduce (Before Fix)

1. Open a workspace in CodexMonitor
2. Have uncommitted changes that would conflict with a target branch
3. Use the branch switcher (`Cmd+B`) to switch branches
4. Observe that if the checkout fails due to conflicts, `git status` may show you on the new branch but with the old tree, or vice versa

Alternatively:
1. Try to switch to a branch name that doesn't exist
2. Before this fix, HEAD could be set to an invalid ref before the error was raised

## Testing

Added a unit test `checkout_branch_missing_does_not_change_head` that:
- Creates a temp repo with an initial commit
- Attempts to checkout a non-existent branch
- Asserts HEAD remains unchanged after the error