### PR TITLE
feat: add copy file name/path to git file menu

### DIFF
--- a/src/features/git/components/GitDiffPanel.test.tsx
+++ b/src/features/git/components/GitDiffPanel.test.tsx
@@ -208,4 +208,33 @@ describe("GitDiffPanel", () => {
 
     expect(clipboardWriteText).toHaveBeenCalledWith("apps/src/sample.ts");
   });
+
+  it("does not trim paths when the git root only shares a prefix", async () => {
+    clipboardWriteText.mockClear();
+    const { container } = render(
+      <GitDiffPanel
+        {...baseProps}
+        workspacePath="/tmp/repo"
+        gitRoot="/tmp/repo-tools"
+        unstagedFiles={[
+          { path: "src/sample.ts", status: "M", additions: 1, deletions: 0 },
+        ]}
+      />,
+    );
+
+    const row = container.querySelector(".diff-row");
+    expect(row).not.toBeNull();
+    fireEvent.contextMenu(row as Element);
+
+    await waitFor(() => expect(menuNew).toHaveBeenCalled());
+    const menuArgs = menuNew.mock.calls[menuNew.mock.calls.length - 1]?.[0];
+    const copyPathItem = menuArgs.items.find(
+      (item: { text: string }) => item.text === "Copy file path",
+    );
+
+    expect(copyPathItem).toBeDefined();
+    await copyPathItem.action();
+
+    expect(clipboardWriteText).toHaveBeenCalledWith("src/sample.ts");
+  });
 });


### PR DESCRIPTION
## Summary
- add "Copy file name" and "Copy file path" actions to the git file context menu
- reuse the resolved root/path logic for absolute paths
- cover the new menu actions with tests

## Motivation
Quickly grab a file name or full path from the git changes list without leaving the app.

<img width="363" height="276" alt="Screenshot 2026-02-05 at 09 20 54" src="https://github.com/user-attachments/assets/e320b676-2eb9-42ee-93a8-4db8fb359f0f" />

## Testing
- npm run test
- npm run tauri build (fails: bundle_dmg.sh)