### PR TITLE
fix: remote add workspace path prompt

### DIFF
--- a/src/features/app/components/AppModals.tsx
+++ b/src/features/app/components/AppModals.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from "react";
 import type { BranchInfo, WorkspaceInfo } from "../../../types";
 import type { SettingsViewProps } from "../../settings/components/SettingsView";
 import { useRenameThreadPrompt } from "../../threads/hooks/useRenameThreadPrompt";
+import { useAddWorkspacePrompt } from "../../workspaces/hooks/useAddWorkspacePrompt";
 import { useClonePrompt } from "../../workspaces/hooks/useClonePrompt";
 import { useWorktreePrompt } from "../../workspaces/hooks/useWorktreePrompt";
 import type { BranchSwitcherState } from "../../git/hooks/useBranchSwitcher";
@@ -23,6 +24,11 @@ const ClonePrompt = lazy(() =>
     default: module.ClonePrompt,
   })),
 );
+const AddWorkspacePrompt = lazy(() =>
+  import("../../workspaces/components/AddWorkspacePrompt").then((module) => ({
+    default: module.AddWorkspacePrompt,
+  })),
+);
 const BranchSwitcherPrompt = lazy(() =>
   import("../../git/components/BranchSwitcherPrompt").then((module) => ({
     default: module.BranchSwitcherPrompt,
@@ -35,11 +41,18 @@ type WorktreePromptState = ReturnType<typeof useWorktreePrompt>["worktreePrompt"
 
 type ClonePromptState = ReturnType<typeof useClonePrompt>["clonePrompt"];
 
+type AddWorkspacePromptState =
+  ReturnType<typeof useAddWorkspacePrompt>["addWorkspacePrompt"];
+
 type AppModalsProps = {
   renamePrompt: RenamePromptState;
   onRenamePromptChange: (value: string) => void;
   onRenamePromptCancel: () => void;
   onRenamePromptConfirm: () => void;
+  addWorkspacePrompt: AddWorkspacePromptState;
+  onAddWorkspacePromptChange: (value: string) => void;
+  onAddWorkspacePromptCancel: () => void;
+  onAddWorkspacePromptConfirm: () => void;
   worktreePrompt: WorktreePromptState;
   onWorktreePromptNameChange: (value: string) => void;
   onWorktreePromptChange: (value: string) => void;
@@ -73,6 +86,10 @@ export const AppModals = memo(function AppModals({
   onRenamePromptChange,
   onRenamePromptCancel,
   onRenamePromptConfirm,
+  addWorkspacePrompt,
+  onAddWorkspacePromptChange,
+  onAddWorkspacePromptCancel,
+  onAddWorkspacePromptConfirm,
   worktreePrompt,
   onWorktreePromptNameChange,
   onWorktreePromptChange,
@@ -114,6 +131,18 @@ export const AppModals = memo(function AppModals({
             onChange={onRenamePromptChange}
             onCancel={onRenamePromptCancel}
             onConfirm={onRenamePromptConfirm}
+          />
+        </Suspense>
+      )}
+      {addWorkspacePrompt && (
+        <Suspense fallback={null}>
+          <AddWorkspacePrompt
+            path={addWorkspacePrompt.path}
+            error={addWorkspacePrompt.error}
+            isBusy={addWorkspacePrompt.isSubmitting}
+            onChange={onAddWorkspacePromptChange}
+            onCancel={onAddWorkspacePromptCancel}
+            onConfirm={onAddWorkspacePromptConfirm}
           />
         </Suspense>
       )}

--- a/src/features/workspaces/components/AddWorkspacePrompt.tsx
+++ b/src/features/workspaces/components/AddWorkspacePrompt.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from "react";
+
+type AddWorkspacePromptProps = {
+  path: string;
+  error?: string | null;
+  onChange: (value: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isBusy?: boolean;
+};
+
+export function AddWorkspacePrompt({
+  path,
+  error = null,
+  onChange,
+  onCancel,
+  onConfirm,
+  isBusy = false,
+}: AddWorkspacePromptProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const canAdd = path.trim().length > 0;
+
+  return (
+    <div className="worktree-modal" role="dialog" aria-modal="true">
+      <div
+        className="worktree-modal-backdrop"
+        onClick={() => {
+          if (!isBusy) {
+            onCancel();
+          }
+        }}
+      />
+      <div className="worktree-modal-card">
+        <div className="worktree-modal-title">Add workspace</div>
+        <div className="worktree-modal-subtitle">
+          Enter a path on the machine running the backend daemon.
+        </div>
+        <label className="worktree-modal-label" htmlFor="add-workspace-path">
+          Workspace path
+        </label>
+        <input
+          id="add-workspace-path"
+          ref={inputRef}
+          className="worktree-modal-input"
+          value={path}
+          placeholder="/home/user/project"
+          autoCorrect="off"
+          autoCapitalize="none"
+          spellCheck={false}
+          disabled={isBusy}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              if (!isBusy) {
+                onCancel();
+              }
+            }
+            if (event.key === "Enter") {
+              event.preventDefault();
+              if (!isBusy && canAdd) {
+                onConfirm();
+              }
+            }
+          }}
+        />
+        {error && <div className="worktree-modal-error">{error}</div>}
+        <div className="worktree-modal-actions">
+          <button
+            className="ghost worktree-modal-button"
+            onClick={onCancel}
+            type="button"
+            disabled={isBusy}
+          >
+            Cancel
+          </button>
+          <button
+            className="primary worktree-modal-button"
+            onClick={onConfirm}
+            type="button"
+            disabled={isBusy || !canAdd}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/features/workspaces/hooks/useAddWorkspacePrompt.ts
+++ b/src/features/workspaces/hooks/useAddWorkspacePrompt.ts
@@ -1,0 +1,125 @@
+import { useCallback, useState } from "react";
+import type { WorkspaceInfo } from "../../../types";
+import { isWorkspacePathDir } from "../../../services/tauri";
+
+type AddWorkspacePromptState = {
+  path: string;
+  isSubmitting: boolean;
+  error: string | null;
+} | null;
+
+type UseAddWorkspacePromptOptions = {
+  addWorkspaceFromPath: (path: string) => Promise<WorkspaceInfo | null>;
+  onWorkspaceAdded?: (workspace: WorkspaceInfo) => void;
+  onError?: (message: string) => void;
+  shouldValidateDir?: boolean;
+};
+
+type UseAddWorkspacePromptResult = {
+  addWorkspacePrompt: AddWorkspacePromptState;
+  openPrompt: (initialPath?: string) => void;
+  cancelPrompt: () => void;
+  confirmPrompt: () => Promise<void>;
+  updatePath: (value: string) => void;
+};
+
+export function useAddWorkspacePrompt({
+  addWorkspaceFromPath,
+  onWorkspaceAdded,
+  onError,
+  shouldValidateDir = true,
+}: UseAddWorkspacePromptOptions): UseAddWorkspacePromptResult {
+  const [addWorkspacePrompt, setAddWorkspacePrompt] =
+    useState<AddWorkspacePromptState>(null);
+
+  const openPrompt = useCallback((initialPath = "") => {
+    setAddWorkspacePrompt({
+      path: initialPath,
+      isSubmitting: false,
+      error: null,
+    });
+  }, []);
+
+  const updatePath = useCallback((value: string) => {
+    setAddWorkspacePrompt((prev) =>
+      prev ? { ...prev, path: value, error: null } : prev,
+    );
+  }, []);
+
+  const cancelPrompt = useCallback(() => {
+    setAddWorkspacePrompt((prev) => {
+      if (!prev || prev.isSubmitting) {
+        return prev;
+      }
+      return null;
+    });
+  }, []);
+
+  const confirmPrompt = useCallback(async () => {
+    if (!addWorkspacePrompt || addWorkspacePrompt.isSubmitting) {
+      return;
+    }
+
+    const snapshot = addWorkspacePrompt;
+    const selection = snapshot.path.trim();
+    if (!selection) {
+      setAddWorkspacePrompt((prev) =>
+        prev ? { ...prev, error: "Workspace path is required." } : prev,
+      );
+      return;
+    }
+
+    setAddWorkspacePrompt((prev) =>
+      prev ? { ...prev, isSubmitting: true, error: null } : prev,
+    );
+
+    if (shouldValidateDir) {
+      try {
+        const isDir = await isWorkspacePathDir(selection);
+        if (!isDir) {
+          setAddWorkspacePrompt((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  isSubmitting: false,
+                  error: "Path is not a directory.",
+                }
+              : prev,
+          );
+          return;
+        }
+      } catch {
+        // Best-effort validation; the actual add call will surface errors.
+      }
+    }
+
+    try {
+      const workspace = await addWorkspaceFromPath(selection);
+      if (workspace) {
+        onWorkspaceAdded?.(workspace);
+      }
+      setAddWorkspacePrompt(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setAddWorkspacePrompt((prev) =>
+        prev ? { ...prev, isSubmitting: false, error: message } : prev,
+      );
+      onError?.(message);
+    }
+  }, [
+    addWorkspaceFromPath,
+    addWorkspacePrompt,
+    onError,
+    onWorkspaceAdded,
+    shouldValidateDir,
+  ]);
+
+  return {
+    addWorkspacePrompt,
+    openPrompt,
+    cancelPrompt,
+    confirmPrompt,
+    updatePath,
+  };
+}
+


### PR DESCRIPTION
In backendMode=remote, Add workspace previously used the local OS folder picker (macOS path), which then failed validation on the remote daemon host.\n\nThis adds a remote-friendly Add Workspace modal that prompts for a path string on the daemon host and routes through the existing addWorkspaceFromPath() flow; local mode behavior is unchanged.\n\nValidation:\n- npm run lint\n- npm run test\n- npm run typecheck\n- (src-tauri) cargo check\n