### PR TITLE
Disable branch search autocorrect

### DIFF
--- a/src/features/app/components/MainHeader.tsx
+++ b/src/features/app/components/MainHeader.tsx
@@ -412,6 +412,9 @@ export function MainHeader({
                         }}
                         placeholder="Search or create branch"
                         className="branch-input"
+                        autoCorrect="off"
+                        autoCapitalize="none"
+                        spellCheck={false}
                         autoFocus
                         data-tauri-drag-region="false"
                         aria-label="Search branches"


### PR DESCRIPTION
## Summary
- disable autocorrect, auto-capitalization, and spellcheck for the branch search input

## Screenshots
| Before | After |
| --- | --- |
| <img width="323" height="97" alt="Screenshot 2026-02-06 at 4 00 50 PM" src="https://github.com/user-attachments/assets/35275a91-9392-4d22-8a86-3c6d110a2da0" /> | <img width="331" height="104" alt="Screenshot 2026-02-06 at 4 02 35 PM" src="https://github.com/user-attachments/assets/9d8870ec-4c6c-4a2e-b889-c330245e4acc" /> |

## Testing
- npm run tauri dev