### PR TITLE
Fix Windows cmd wrapper argument quoting

### DIFF
--- a/src-tauri/src/backend/app_server.rs
+++ b/src-tauri/src/backend/app_server.rs
@@ -19,6 +19,8 @@ use crate::types::WorkspaceEntry;
 
 #[cfg(target_os = "windows")]
 use crate::shared::process_core::{build_cmd_c_command, resolve_windows_executable};
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 
 fn extract_thread_id(value: &Value) -> Option<String> {
     let params = value.get("params")?;
@@ -210,7 +212,7 @@ pub(crate) fn build_codex_command_with_bin(
             command.arg("/D");
             command.arg("/S");
             command.arg("/C");
-            command.arg(command_line);
+            command.raw_arg(command_line);
             command
         } else {
             let mut command = tokio_command(resolved_path);

--- a/src-tauri/src/workspaces/commands.rs
+++ b/src-tauri/src/workspaces/commands.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 #[cfg(target_os = "windows")]
 use std::path::Path;
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -855,7 +857,7 @@ pub(crate) async fn open_workspace_in(
                 cmd.arg("/D");
                 cmd.arg("/S");
                 cmd.arg("/C");
-                cmd.arg(command_line);
+                cmd.raw_arg(command_line);
                 cmd
             } else {
                 let mut cmd = tokio_command(resolved_path);


### PR DESCRIPTION
### Motivation
- Windows `.cmd`/`.bat` invocations were being double-quoted when building the `cmd.exe /C` payload which caused the spawned process to be treated as a single invalid command, so the launcher must pass the payload as a raw argument to avoid extra quoting.

### Description
- Use `CommandExt` and pass the `cmd.exe /C` payload with `raw_arg(...)` instead of `arg(...)` so the inner quoted command is not re-quoted by the Rust process API.
- Applied the fix in `src-tauri/src/backend/app_server.rs` for Codex app-server launches and in `src-tauri/src/workspaces/commands.rs` for the workspace `open in` command path when resolving `.cmd`/`.bat` targets.
- Existing non-Windows code paths and the `PATH` environment construction remain unchanged.

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully. 
- Ran `npm run test` (Vitest) and all frontend tests passed (`70` test files, `377` tests passed). 
- Ran `cargo check` in `src-tauri` but it failed due to a missing system dependency (`glib-2.0`) in the environment, not related to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986d28984d0832598a17a62fd9281ae)