### PR TITLE
fix: mitigate Linux X11 blank WebKit renders

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,10 @@ pub fn run() {
         if std::env::var_os("__NV_PRIME_RENDER_OFFLOAD").is_none() {
             std::env::set_var("__NV_PRIME_RENDER_OFFLOAD", "1");
         }
+        // Work around sporadic blank WebKitGTK renders on X11 by disabling compositing mode.
+        if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
     }
 
     let builder = tauri::Builder::default()


### PR DESCRIPTION
### Motivation
- Work around sporadic blank main-window renders observed on X11/WebKitGTK (app becomes visually blank when switching focus) by disabling WebKit compositing at process start on Linux.

### Description
- Set `WEBKIT_DISABLE_COMPOSITING_MODE=1` when unset during startup on Linux in `src-tauri/src/lib.rs` to avoid compositing-related blanking; preserves the existing `__NV_PRIME_RENDER_OFFLOAD` workaround.

### Testing
- No automated tests were run because this is an environment-only startup change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a2bdbeec83259af946e69045e340)