### PR TITLE
fix: editable git prompt template in Git settings

### DIFF
--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -592,6 +592,11 @@ pub(crate) struct AppSettings {
     )]
     pub(crate) git_diff_ignore_whitespace_changes: bool,
     #[serde(
+        default = "default_git_pull_request_prompt",
+        rename = "gitPullRequestPrompt"
+    )]
+    pub(crate) git_pull_request_prompt: String,
+    #[serde(
         default = "default_system_notifications_enabled",
         rename = "systemNotificationsEnabled"
     )]
@@ -924,6 +929,20 @@ fn default_git_diff_ignore_whitespace_changes() -> bool {
     false
 }
 
+fn default_git_pull_request_prompt() -> String {
+    [
+        "You are reviewing a GitHub pull request.",
+        "PR: #{{number}} {{title}}",
+        "URL: {{url}}",
+        "Author: @{{author}}",
+        "Branches: {{baseRef}} <- {{headRef}}",
+        "Updated: {{updatedAt}}{{draftState}}{{descriptionSection}}",
+        "",
+        "Diff: {{diffSummary}}{{questionSection}}",
+    ]
+    .join("\n")
+}
+
 fn default_experimental_collab_enabled() -> bool {
     false
 }
@@ -1169,6 +1188,7 @@ impl Default for AppSettings {
             system_notifications_enabled: true,
             preload_git_diffs: default_preload_git_diffs(),
             git_diff_ignore_whitespace_changes: default_git_diff_ignore_whitespace_changes(),
+            git_pull_request_prompt: default_git_pull_request_prompt(),
             experimental_collab_enabled: false,
             collaboration_modes_enabled: true,
             steer_enabled: true,
@@ -1329,6 +1349,10 @@ mod tests {
         assert!(settings.system_notifications_enabled);
         assert!(settings.preload_git_diffs);
         assert!(!settings.git_diff_ignore_whitespace_changes);
+        assert_eq!(
+            settings.git_pull_request_prompt,
+            default_git_pull_request_prompt()
+        );
         assert!(settings.collaboration_modes_enabled);
         assert!(settings.steer_enabled);
         assert!(settings.unified_exec_enabled);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1543,6 +1543,7 @@ function MainApp() {
     activeWorkspace,
     selectedPullRequest,
     gitPullRequestDiffs,
+    gitPullRequestPromptTemplate: appSettings.gitPullRequestPrompt,
     filePanelMode,
     gitPanelMode,
     centerMode,

--- a/src/features/git/hooks/usePullRequestComposer.test.tsx
+++ b/src/features/git/hooks/usePullRequestComposer.test.tsx
@@ -54,6 +54,7 @@ const makeOptions = (overrides: Partial<Parameters<typeof usePullRequestComposer
   activeWorkspace: connectedWorkspace,
   selectedPullRequest: null,
   gitPullRequestDiffs: diffs,
+  gitPullRequestPromptTemplate: "Default template",
   filePanelMode: "git" as const,
   gitPanelMode: "prs" as const,
   centerMode: "diff" as const,
@@ -141,6 +142,7 @@ describe("usePullRequestComposer", () => {
       pullRequest,
       diffs,
       "Question?",
+      "Default template",
     );
     expect(options.startThreadForWorkspace).toHaveBeenCalledWith(
       disconnectedWorkspace.id,
@@ -193,6 +195,7 @@ describe("usePullRequestComposer", () => {
       pullRequest,
       diffs,
       "/src-tauri/something",
+      "Default template",
     );
     expect(options.startThreadForWorkspace).toHaveBeenCalledWith(
       connectedWorkspace.id,

--- a/src/features/git/hooks/usePullRequestComposer.ts
+++ b/src/features/git/hooks/usePullRequestComposer.ts
@@ -11,6 +11,7 @@ type UsePullRequestComposerOptions = {
   activeWorkspace: WorkspaceInfo | null;
   selectedPullRequest: GitHubPullRequest | null;
   gitPullRequestDiffs: GitHubPullRequestDiff[];
+  gitPullRequestPromptTemplate: string;
   filePanelMode: "git" | "files" | "prompts";
   gitPanelMode: "diff" | "log" | "issues" | "prs";
   centerMode: "chat" | "diff";
@@ -40,6 +41,7 @@ export function usePullRequestComposer({
   activeWorkspace,
   selectedPullRequest,
   gitPullRequestDiffs,
+  gitPullRequestPromptTemplate,
   filePanelMode,
   gitPanelMode,
   centerMode,
@@ -120,6 +122,7 @@ export function usePullRequestComposer({
         selectedPullRequest,
         gitPullRequestDiffs,
         trimmed,
+        gitPullRequestPromptTemplate,
       );
       const threadId = await startThreadForWorkspace(activeWorkspace.id, {
         activate: false,
@@ -135,6 +138,7 @@ export function usePullRequestComposer({
       clearActiveImages,
       connectWorkspace,
       gitPullRequestDiffs,
+      gitPullRequestPromptTemplate,
       handleSend,
       selectedPullRequest,
       sendUserMessageToThread,

--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { AppSettings, WorkspaceInfo } from "../../../types";
+import { DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE } from "../../../utils/pullRequestPrompt";
 import { SettingsView } from "./SettingsView";
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -68,6 +69,7 @@ const baseSettings: AppSettings = {
   systemNotificationsEnabled: true,
   preloadGitDiffs: true,
   gitDiffIgnoreWhitespaceChanges: false,
+  gitPullRequestPrompt: DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE,
   experimentalCollabEnabled: false,
   collaborationModesEnabled: true,
   steerEnabled: true,

--- a/src/features/settings/components/sections/SettingsGitSection.tsx
+++ b/src/features/settings/components/sections/SettingsGitSection.tsx
@@ -3,17 +3,29 @@ import type { AppSettings } from "../../../../types";
 type SettingsGitSectionProps = {
   appSettings: AppSettings;
   onUpdateAppSettings: (next: AppSettings) => Promise<void>;
+  gitPullRequestPromptDraft: string;
+  gitPullRequestPromptDirty: boolean;
+  gitPullRequestPromptSaving: boolean;
+  onSetGitPullRequestPromptDraft: (next: string) => void;
+  onSaveGitPullRequestPrompt: () => Promise<void>;
+  onResetGitPullRequestPrompt: () => Promise<void>;
 };
 
 export function SettingsGitSection({
   appSettings,
   onUpdateAppSettings,
+  gitPullRequestPromptDraft,
+  gitPullRequestPromptDirty,
+  gitPullRequestPromptSaving,
+  onSetGitPullRequestPromptDraft,
+  onSaveGitPullRequestPrompt,
+  onResetGitPullRequestPrompt,
 }: SettingsGitSectionProps) {
   return (
     <section className="settings-section">
       <div className="settings-section-title">Git</div>
       <div className="settings-section-subtitle">
-        Manage how diffs are loaded in the Git sidebar.
+        Manage how diffs are loaded and pull request prompts are composed.
       </div>
       <div className="settings-toggle-row">
         <div>
@@ -54,6 +66,47 @@ export function SettingsGitSection({
         >
           <span className="settings-toggle-knob" />
         </button>
+      </div>
+      <div className="settings-field">
+        <label className="settings-field-label" htmlFor="git-pr-prompt">
+          Pull request prompt
+        </label>
+        <div className="settings-help">
+          Template used when asking questions about GitHub pull requests. Available tokens:{" "}
+          <code>{"{{number}}"}</code>, <code>{"{{title}}"}</code>,{" "}
+          <code>{"{{url}}"}</code>, <code>{"{{author}}"}</code>,{" "}
+          <code>{"{{baseRef}}"}</code>, <code>{"{{headRef}}"}</code>,{" "}
+          <code>{"{{updatedAt}}"}</code>, <code>{"{{draftState}}"}</code>,{" "}
+          <code>{"{{descriptionSection}}"}</code>, <code>{"{{diffSummary}}"}</code>,{" "}
+          <code>{"{{questionSection}}"}</code>.
+        </div>
+        <textarea
+          id="git-pr-prompt"
+          className="settings-agents-textarea"
+          value={gitPullRequestPromptDraft}
+          onChange={(event) => onSetGitPullRequestPromptDraft(event.target.value)}
+          placeholder="Describe the pull request context for Codex…"
+          spellCheck={false}
+          disabled={gitPullRequestPromptSaving}
+        />
+        <div className="settings-field-actions">
+          <button
+            type="button"
+            className="ghost settings-button-compact"
+            onClick={() => void onResetGitPullRequestPrompt()}
+            disabled={gitPullRequestPromptSaving}
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            className="primary settings-button-compact"
+            onClick={() => void onSaveGitPullRequestPrompt()}
+            disabled={gitPullRequestPromptSaving || !gitPullRequestPromptDirty}
+          >
+            {gitPullRequestPromptSaving ? "Saving..." : "Save"}
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/src/features/settings/hooks/useAppSettings.ts
+++ b/src/features/settings/hooks/useAppSettings.ts
@@ -17,6 +17,7 @@ import {
 import { normalizeOpenAppTargets } from "../../app/utils/openApp";
 import { getDefaultInterruptShortcut, isMacPlatform } from "../../../utils/shortcuts";
 import { isMobilePlatform } from "../../../utils/platformPaths";
+import { DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE } from "../../../utils/pullRequestPrompt";
 
 const allowedThemes = new Set(["system", "light", "dark", "dim"]);
 const allowedPersonality = new Set(["friendly", "pragmatic"]);
@@ -72,6 +73,7 @@ function buildDefaultSettings(): AppSettings {
     systemNotificationsEnabled: true,
     preloadGitDiffs: true,
     gitDiffIgnoreWhitespaceChanges: false,
+    gitPullRequestPrompt: DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE,
     experimentalCollabEnabled: false,
     collaborationModesEnabled: true,
     steerEnabled: true,
@@ -133,6 +135,9 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
       DEFAULT_CODE_FONT_FAMILY,
     ),
     codeFontSize: clampCodeFontSize(settings.codeFontSize),
+    gitPullRequestPrompt: settings.gitPullRequestPrompt?.trim()
+      ? settings.gitPullRequestPrompt
+      : DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE,
     personality: allowedPersonality.has(settings.personality)
       ? settings.personality
       : "friendly",

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,7 @@ export type AppSettings = {
   systemNotificationsEnabled: boolean;
   preloadGitDiffs: boolean;
   gitDiffIgnoreWhitespaceChanges: boolean;
+  gitPullRequestPrompt: string;
   experimentalCollabEnabled: boolean;
   collaborationModesEnabled: boolean;
   steerEnabled: boolean;

--- a/src/utils/pullRequestPrompt.ts
+++ b/src/utils/pullRequestPrompt.ts
@@ -1,5 +1,16 @@
 import type { GitHubPullRequest, GitHubPullRequestDiff } from "../types";
 
+export const DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE = `You are reviewing a GitHub pull request.
+PR: #{{number}} {{title}}
+URL: {{url}}
+Author: @{{author}}
+Branches: {{baseRef}} <- {{headRef}}
+Updated: {{updatedAt}}{{draftState}}{{descriptionSection}}
+
+Diff: {{diffSummary}}{{questionSection}}`;
+
+const TEMPLATE_TOKEN_REGEX = /{{\s*([a-zA-Z0-9_]+)\s*}}/g;
+
 export function buildPullRequestDraft(pullRequest: GitHubPullRequest) {
   return `Question about PR #${pullRequest.number} (${pullRequest.title}):\n`;
 }
@@ -8,36 +19,40 @@ export function buildPullRequestPrompt(
   pullRequest: GitHubPullRequest,
   diffs: GitHubPullRequestDiff[],
   question: string,
+  template: string = DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE,
 ) {
   const author = pullRequest.author?.login ?? "unknown";
-  const lines: string[] = [
-    "You are reviewing a GitHub pull request.",
-    `PR: #${pullRequest.number} ${pullRequest.title}`,
-    `URL: ${pullRequest.url}`,
-    `Author: @${author}`,
-    `Branches: ${pullRequest.baseRefName} <- ${pullRequest.headRefName}`,
-    `Updated: ${pullRequest.updatedAt}`,
-  ];
-
-  if (pullRequest.isDraft) {
-    lines.push("State: draft");
-  }
-
-  const body = pullRequest.body?.trim();
-  if (body) {
-    lines.push("", "Description:", body);
-  }
-
-  const diffNote =
+  const diffSummary =
     diffs.length === 0
-      ? "Diff: unavailable in this message."
-      : `Diff: ${diffs.length} file${diffs.length === 1 ? "" : "s"} changed (not included).`;
-  lines.push("", diffNote);
-
+      ? "unavailable in this message."
+      : `${diffs.length} file${diffs.length === 1 ? "" : "s"} changed (not included).`;
+  const draftState = pullRequest.isDraft ? "\nState: draft" : "";
+  const body = pullRequest.body?.trim();
+  const descriptionSection = body ? `\n\nDescription:\n${body}` : "";
   const trimmedQuestion = question.trim();
-  if (trimmedQuestion) {
-    lines.push("", "Question:", trimmedQuestion);
-  }
+  const questionSection = trimmedQuestion
+    ? `\n\nQuestion:\n${trimmedQuestion}`
+    : "";
+  const resolvedTemplate = template.trim()
+    ? template
+    : DEFAULT_PULL_REQUEST_PROMPT_TEMPLATE;
+  const valueMap: Record<string, string> = {
+    number: pullRequest.number.toString(),
+    title: pullRequest.title,
+    url: pullRequest.url,
+    author,
+    baseRef: pullRequest.baseRefName,
+    headRef: pullRequest.headRefName,
+    updatedAt: pullRequest.updatedAt,
+    draftState,
+    descriptionSection,
+    diffSummary,
+    questionSection,
+  };
+  const filled = resolvedTemplate.replace(
+    TEMPLATE_TOKEN_REGEX,
+    (_, key) => valueMap[key] ?? "",
+  );
 
-  return lines.join("\n");
+  return filled.replace(/\n{3,}/g, "\n\n").trim();
 }


### PR DESCRIPTION
### Motivation
- Provide a way for users to customize the default PR prompt used when asking questions about GitHub pull requests from the Git panel. 

### Description
- Add a new `gitPullRequestPrompt` setting (frontend `src/types.ts`, backend `src-tauri/src/types.rs`) with a default template and normalization in `useAppSettings`. 
- Expose an editable textarea in the Git section of Settings with save/reset controls and draft handling (`SettingsGitSection.tsx`, `SettingsView.tsx`).
- Extend the PR prompt generator to accept a template with tokens and fill them (`src/utils/pullRequestPrompt.ts`), and wire the configurable template into the PR composer flow (`usePullRequestComposer.ts`, `App.tsx`).
- Update tests and test fixtures to exercise template passing (`usePullRequestComposer.test.tsx`, `SettingsView.test.tsx`).

### Testing
- Ran `npm run lint` and it completed successfully after fixes. 
- Ran `npm run test` (Vitest) and the full test suite passed (`439 passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `cargo check` in `src-tauri` which failed due to a missing system dependency (`glib-2.0`) in the environment and is unrelated to the added Rust serialization changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a179bbb78832585f3081ae72a7219)