### PR TITLE
feat(settings/git): expose editable commit-message prompt in Git settings

### DIFF
--- a/src-tauri/src/bin/codex_monitor_daemon.rs
+++ b/src-tauri/src/bin/codex_monitor_daemon.rs
@@ -1109,7 +1109,14 @@ impl DaemonState {
         if diff.trim().is_empty() {
             return Err("No changes to generate commit message for".to_string());
         }
-        Ok(codex_aux_core::build_commit_message_prompt(&diff))
+        let commit_message_prompt = {
+            let settings = self.app_settings.lock().await;
+            settings.commit_message_prompt.clone()
+        };
+        Ok(codex_aux_core::build_commit_message_prompt(
+            &diff,
+            &commit_message_prompt,
+        ))
     }
 
     async fn generate_commit_message(&self, workspace_id: String) -> Result<String, String> {
@@ -1122,7 +1129,14 @@ impl DaemonState {
         if diff.trim().is_empty() {
             return Err("No changes to generate commit message for".to_string());
         }
-        let prompt = codex_aux_core::build_commit_message_prompt(&diff);
+        let commit_message_prompt = {
+            let settings = self.app_settings.lock().await;
+            settings.commit_message_prompt.clone()
+        };
+        let prompt = codex_aux_core::build_commit_message_prompt(
+            &diff,
+            &commit_message_prompt,
+        );
         let response = codex_aux_core::run_background_prompt_core(
             &self.sessions,
             workspace_id,

--- a/src-tauri/src/codex/mod.rs
+++ b/src-tauri/src/codex/mod.rs
@@ -575,8 +575,14 @@ pub(crate) async fn get_commit_message_prompt(
         return Err("No changes to generate commit message for".to_string());
     }
 
+    let commit_message_prompt = {
+        let settings = state.app_settings.lock().await;
+        settings.commit_message_prompt.clone()
+    };
+
     Ok(crate::shared::codex_aux_core::build_commit_message_prompt(
         &diff,
+        &commit_message_prompt,
     ))
 }
 
@@ -632,7 +638,14 @@ pub(crate) async fn generate_commit_message(
         return Err("No changes to generate commit message for".to_string());
     }
 
-    let prompt = crate::shared::codex_aux_core::build_commit_message_prompt(&diff);
+    let commit_message_prompt = {
+        let settings = state.app_settings.lock().await;
+        settings.commit_message_prompt.clone()
+    };
+    let prompt = crate::shared::codex_aux_core::build_commit_message_prompt(
+        &diff,
+        &commit_message_prompt,
+    );
     let response = crate::shared::codex_aux_core::run_background_prompt_core(
         &state.sessions,
         workspace_id,

--- a/src-tauri/src/shared/codex_aux_core.rs
+++ b/src-tauri/src/shared/codex_aux_core.rs
@@ -12,14 +12,23 @@ use crate::backend::app_server::{
 use crate::shared::process_core::tokio_command;
 use crate::types::AppSettings;
 
-pub(crate) fn build_commit_message_prompt(diff: &str) -> String {
-    format!(
-        "Generate a concise git commit message for the following changes. \
+const DEFAULT_COMMIT_MESSAGE_PROMPT: &str = "Generate a concise git commit message for the following changes. \
 Follow conventional commit format (e.g., feat:, fix:, refactor:, docs:, etc.). \
 Keep the summary line under 72 characters. \
 Only output the commit message, nothing else.\n\n\
-Changes:\n{diff}"
-    )
+Changes:\n{diff}";
+
+pub(crate) fn build_commit_message_prompt(diff: &str, template: &str) -> String {
+    let base = if template.trim().is_empty() {
+        DEFAULT_COMMIT_MESSAGE_PROMPT
+    } else {
+        template
+    };
+    if base.contains("{diff}") {
+        base.replace("{diff}", diff)
+    } else {
+        format!("{base}\n\nChanges:\n{diff}")
+    }
 }
 
 pub(crate) fn build_run_metadata_prompt(cleaned_prompt: &str) -> String {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -592,6 +592,11 @@ pub(crate) struct AppSettings {
     )]
     pub(crate) git_diff_ignore_whitespace_changes: bool,
     #[serde(
+        default = "default_commit_message_prompt",
+        rename = "commitMessagePrompt"
+    )]
+    pub(crate) commit_message_prompt: String,
+    #[serde(
         default = "default_system_notifications_enabled",
         rename = "systemNotificationsEnabled"
     )]
@@ -924,6 +929,15 @@ fn default_git_diff_ignore_whitespace_changes() -> bool {
     false
 }
 
+fn default_commit_message_prompt() -> String {
+    "Generate a concise git commit message for the following changes. \
+Follow conventional commit format (e.g., feat:, fix:, refactor:, docs:, etc.). \
+Keep the summary line under 72 characters. \
+Only output the commit message, nothing else.\n\n\
+Changes:\n{diff}"
+        .to_string()
+}
+
 fn default_experimental_collab_enabled() -> bool {
     false
 }
@@ -1169,6 +1183,7 @@ impl Default for AppSettings {
             system_notifications_enabled: true,
             preload_git_diffs: default_preload_git_diffs(),
             git_diff_ignore_whitespace_changes: default_git_diff_ignore_whitespace_changes(),
+            commit_message_prompt: default_commit_message_prompt(),
             experimental_collab_enabled: false,
             collaboration_modes_enabled: true,
             steer_enabled: true,
@@ -1329,6 +1344,7 @@ mod tests {
         assert!(settings.system_notifications_enabled);
         assert!(settings.preload_git_diffs);
         assert!(!settings.git_diff_ignore_whitespace_changes);
+        assert!(settings.commit_message_prompt.contains("{diff}"));
         assert!(settings.collaboration_modes_enabled);
         assert!(settings.steer_enabled);
         assert!(settings.unified_exec_enabled);

--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { AppSettings, WorkspaceInfo } from "../../../types";
+import { DEFAULT_COMMIT_MESSAGE_PROMPT } from "../../../utils/commitMessagePrompt";
 import { SettingsView } from "./SettingsView";
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -68,6 +69,7 @@ const baseSettings: AppSettings = {
   systemNotificationsEnabled: true,
   preloadGitDiffs: true,
   gitDiffIgnoreWhitespaceChanges: false,
+  commitMessagePrompt: DEFAULT_COMMIT_MESSAGE_PROMPT,
   experimentalCollabEnabled: false,
   collaborationModesEnabled: true,
   steerEnabled: true,

--- a/src/features/settings/components/sections/SettingsGitSection.tsx
+++ b/src/features/settings/components/sections/SettingsGitSection.tsx
@@ -3,11 +3,23 @@ import type { AppSettings } from "../../../../types";
 type SettingsGitSectionProps = {
   appSettings: AppSettings;
   onUpdateAppSettings: (next: AppSettings) => Promise<void>;
+  commitMessagePromptDraft: string;
+  commitMessagePromptDirty: boolean;
+  commitMessagePromptSaving: boolean;
+  onSetCommitMessagePromptDraft: (value: string) => void;
+  onSaveCommitMessagePrompt: () => Promise<void>;
+  onResetCommitMessagePrompt: () => Promise<void>;
 };
 
 export function SettingsGitSection({
   appSettings,
   onUpdateAppSettings,
+  commitMessagePromptDraft,
+  commitMessagePromptDirty,
+  commitMessagePromptSaving,
+  onSetCommitMessagePromptDraft,
+  onSaveCommitMessagePrompt,
+  onResetCommitMessagePrompt,
 }: SettingsGitSectionProps) {
   return (
     <section className="settings-section">
@@ -54,6 +66,42 @@ export function SettingsGitSection({
         >
           <span className="settings-toggle-knob" />
         </button>
+      </div>
+      <div className="settings-field">
+        <div className="settings-field-label">Commit message prompt</div>
+        <div className="settings-help">
+          Used when generating commit messages. Include <code>{"{diff}"}</code> to insert the
+          git diff.
+        </div>
+        <textarea
+          className="settings-agents-textarea"
+          value={commitMessagePromptDraft}
+          onChange={(event) => onSetCommitMessagePromptDraft(event.target.value)}
+          spellCheck={false}
+          disabled={commitMessagePromptSaving}
+        />
+        <div className="settings-field-actions">
+          <button
+            type="button"
+            className="ghost settings-button-compact"
+            onClick={() => {
+              void onResetCommitMessagePrompt();
+            }}
+            disabled={commitMessagePromptSaving || !commitMessagePromptDirty}
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            className="primary settings-button-compact"
+            onClick={() => {
+              void onSaveCommitMessagePrompt();
+            }}
+            disabled={commitMessagePromptSaving || !commitMessagePromptDirty}
+          >
+            {commitMessagePromptSaving ? "Saving..." : "Save"}
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/src/features/settings/hooks/useAppSettings.ts
+++ b/src/features/settings/hooks/useAppSettings.ts
@@ -17,6 +17,7 @@ import {
 import { normalizeOpenAppTargets } from "../../app/utils/openApp";
 import { getDefaultInterruptShortcut, isMacPlatform } from "../../../utils/shortcuts";
 import { isMobilePlatform } from "../../../utils/platformPaths";
+import { DEFAULT_COMMIT_MESSAGE_PROMPT } from "../../../utils/commitMessagePrompt";
 
 const allowedThemes = new Set(["system", "light", "dark", "dim"]);
 const allowedPersonality = new Set(["friendly", "pragmatic"]);
@@ -72,6 +73,7 @@ function buildDefaultSettings(): AppSettings {
     systemNotificationsEnabled: true,
     preloadGitDiffs: true,
     gitDiffIgnoreWhitespaceChanges: false,
+    commitMessagePrompt: DEFAULT_COMMIT_MESSAGE_PROMPT,
     experimentalCollabEnabled: false,
     collaborationModesEnabled: true,
     steerEnabled: true,
@@ -118,6 +120,10 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     : hasStoredSelection
       ? storedOpenAppId
       : normalizedTargets[0]?.id ?? DEFAULT_OPEN_APP_ID;
+  const commitMessagePrompt =
+    settings.commitMessagePrompt && settings.commitMessagePrompt.trim().length > 0
+      ? settings.commitMessagePrompt
+      : DEFAULT_COMMIT_MESSAGE_PROMPT;
   return {
     ...settings,
     codexBin: settings.codexBin?.trim() ? settings.codexBin.trim() : null,
@@ -138,6 +144,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
       : "friendly",
     reviewDeliveryMode:
       settings.reviewDeliveryMode === "detached" ? "detached" : "inline",
+    commitMessagePrompt,
     openAppTargets: normalizedTargets,
     selectedOpenAppId,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,7 @@ export type AppSettings = {
   systemNotificationsEnabled: boolean;
   preloadGitDiffs: boolean;
   gitDiffIgnoreWhitespaceChanges: boolean;
+  commitMessagePrompt: string;
   experimentalCollabEnabled: boolean;
   collaborationModesEnabled: boolean;
   steerEnabled: boolean;

--- a/src/utils/commitMessagePrompt.ts
+++ b/src/utils/commitMessagePrompt.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_COMMIT_MESSAGE_PROMPT = `Generate a concise git commit message for the following changes. Follow conventional commit format (e.g., feat:, fix:, refactor:, docs:, etc.). Keep the summary line under 72 characters. Only output the commit message, nothing else.
+
+Changes:
+{diff}`;


### PR DESCRIPTION
### Motivation
- Provide a user-editable commit-message prompt used by the built-in commit-message generator so teams can customize the template (and preserve the existing generated-message behavior).
- Surface the current prompt in the Settings → Git panel and offer Save/Reset controls consistent with other settings fields.
- Ensure both the app and the daemon use the stored template when building prompts, with a safe default fallback.

### Description
- Added a settings editor UI to the Git section: a textarea with Save and Reset buttons and dirty/saving state handling (`src/features/settings/components/sections/SettingsGitSection.tsx`, `src/features/settings/components/SettingsView.tsx`).
- Persisted a `commitMessagePrompt` field through frontend types/normalization and defaults, and added `DEFAULT_COMMIT_MESSAGE_PROMPT` helper (`src/types.ts`, `src/features/settings/hooks/useAppSettings.ts`, `src/utils/commitMessagePrompt.ts`).
- Updated shared backend prompt builder to accept a template and fall back to the default when the template is empty, and wired the app and daemon to read `commit_message_prompt` from app settings when composing the final commit-message prompt (`src-tauri/src/shared/codex_aux_core.rs`, `src-tauri/src/codex/mod.rs`, `src-tauri/src/bin/codex_monitor_daemon.rs`, `src-tauri/src/types.rs`).

### Testing
- Ran `npm run lint` with no reported errors.
- Ran `npm run test` and the test suite completed successfully (`439 passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Ran `cargo check` in `src-tauri` which failed in this environment due to a missing system dependency (`glib-2.0` via pkg-config), not due to code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a299810e483258cada2bd0a381a07)