### PR TITLE
fix: set DMABUF renderer fallback for Wayland + NVIDIA

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,17 @@ pub fn run() {
         if std::env::var_os("__NV_PRIME_RENDER_OFFLOAD").is_none() {
             std::env::set_var("__NV_PRIME_RENDER_OFFLOAD", "1");
         }
+        let is_wayland = std::env::var("XDG_SESSION_TYPE")
+            .map(|session| session.eq_ignore_ascii_case("wayland"))
+            .unwrap_or(false)
+            || std::env::var_os("WAYLAND_DISPLAY").is_some();
+        let has_nvidia = std::path::Path::new("/proc/driver/nvidia/version").exists();
+        if is_wayland
+            && has_nvidia
+            && std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none()
+        {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
         // Work around sporadic blank WebKitGTK renders on X11 by disabling compositing mode.
         if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");


### PR DESCRIPTION
### Motivation
- Provide a built-in fallback to disable WebKit's DMABUF renderer on Wayland when an NVIDIA kernel driver is detected to avoid GBM/EGL initialization failures and crashes.

### Description
- Add a detection in `src-tauri/src/lib.rs` that checks for a Wayland session via `XDG_SESSION_TYPE` or `WAYLAND_DISPLAY` and for NVIDIA via `/proc/driver/nvidia/version`, and sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` when appropriate and the variable is not already set.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Ran `cargo check` in `src-tauri` which failed due to missing system `glib-2.0` development package (`glib-2.0.pc` not found) in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3dd48810832596cccdf8cb003542)