### PR TITLE
fix: keep selected iOS tab when no workspace is active

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1631,8 +1631,6 @@ function MainApp() {
 
   useTabActivationGuard({
     activeTab,
-    activeWorkspace,
-    isPhone,
     isTablet,
     setActiveTab,
   });

--- a/src/features/app/hooks/useTabActivationGuard.test.tsx
+++ b/src/features/app/hooks/useTabActivationGuard.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useTabActivationGuard } from "./useTabActivationGuard";
+
+describe("useTabActivationGuard", () => {
+  it("does not force home tab on phone when no workspace is selected", () => {
+    const setActiveTab = vi.fn();
+
+    renderHook(() =>
+      useTabActivationGuard({
+        activeTab: "git",
+        isTablet: false,
+        setActiveTab,
+      }),
+    );
+
+    expect(setActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("redirects tablet home tab selection to codex", () => {
+    const setActiveTab = vi.fn();
+
+    renderHook(() =>
+      useTabActivationGuard({
+        activeTab: "home",
+        isTablet: true,
+        setActiveTab,
+      }),
+    );
+
+    expect(setActiveTab).toHaveBeenCalledWith("codex");
+  });
+});

--- a/src/features/app/hooks/useTabActivationGuard.ts
+++ b/src/features/app/hooks/useTabActivationGuard.ts
@@ -1,32 +1,18 @@
 import { useEffect } from "react";
-import type { WorkspaceInfo } from "../../../types";
 
 type AppTab = "home" | "projects" | "codex" | "git" | "log";
 
 type UseTabActivationGuardOptions = {
   activeTab: AppTab;
-  activeWorkspace: WorkspaceInfo | null;
-  isPhone: boolean;
   isTablet: boolean;
   setActiveTab: (tab: AppTab) => void;
 };
 
 export function useTabActivationGuard({
   activeTab,
-  activeWorkspace,
-  isPhone,
   isTablet,
   setActiveTab,
 }: UseTabActivationGuardOptions) {
-  useEffect(() => {
-    if (!isPhone) {
-      return;
-    }
-    if (!activeWorkspace && activeTab !== "home" && activeTab !== "projects") {
-      setActiveTab("home");
-    }
-  }, [activeTab, activeWorkspace, isPhone, setActiveTab]);
-
   useEffect(() => {
     if (!isTablet) {
       return;


### PR DESCRIPTION
## Summary
This PR fixes an iOS tab-state issue where selecting **Codex/Git/Log** could still end up with **Home** selected when no workspace was active.

## Root Cause
`useTabActivationGuard` forced phone layouts without an active workspace back to `home`, overriding user tab selection for `codex`, `git`, and `log`.

## Changes
- Removed the phone-specific fallback-to-home logic in `useTabActivationGuard`.
- Kept the tablet-specific guard unchanged (`home/projects` -> `codex`).
- Updated the `App.tsx` callsite to match the simplified hook API.
- Added regression tests to ensure:
  - phone mode does not force `home` for non-home tabs without a workspace
  - tablet mode still redirects `home` to `codex`

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test`
