### PR TITLE
fix(windows): suppress git check-ignore console popups during workspace polling

### DIFF
--- a/src-tauri/src/shared/git_ui_core/diff.rs
+++ b/src-tauri/src/shared/git_ui_core/diff.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex;
 use crate::git_utils::{
     diff_patch_to_string, diff_stats_for_path, image_mime_type, resolve_git_root,
 };
+use crate::shared::process_core::std_command;
 use crate::types::{AppSettings, GitCommitDiff, GitFileDiff, GitFileStatus, WorkspaceEntry};
 use crate::utils::{git_env_path, normalize_git_path, resolve_git_binary};
 
@@ -147,7 +148,7 @@ pub(super) fn collect_ignored_paths_with_git(
 
     let repo_root = repo.workdir()?;
     let git_bin = resolve_git_binary().ok()?;
-    let mut child = std::process::Command::new(git_bin)
+    let mut child = std_command(git_bin)
         .arg("check-ignore")
         .arg("--stdin")
         .arg("-z")

--- a/src-tauri/src/shared/process_core.rs
+++ b/src-tauri/src/shared/process_core.rs
@@ -25,6 +25,12 @@ pub(crate) fn tokio_command(program: impl AsRef<OsStr>) -> Command {
     command
 }
 
+pub(crate) fn std_command(program: impl AsRef<OsStr>) -> std::process::Command {
+    let mut command = std::process::Command::new(program);
+    hide_console_on_windows(&mut command);
+    command
+}
+
 pub(crate) async fn kill_child_process_tree(child: &mut Child) {
     #[cfg(windows)]
     {


### PR DESCRIPTION
### Motivation
- On Windows the app could spawn visible CMD windows when running `git check-ignore` during workspace polling, causing disruptive console popups.

### Description
- Add `std_command` in `src-tauri/src/shared/process_core.rs` to construct a `std::process::Command` with `CREATE_NO_WINDOW` applied on Windows so synchronous subprocesses run hidden.
- Route the `git check-ignore` invocation in `src-tauri/src/shared/git_ui_core/diff.rs` through the new `std_command` helper so spawned git processes no longer open visible consoles.
- Preserve existing `tokio_command` behavior for async spawns and apply the same Windows-safe logic for synchronous command usage.

### Testing
- Ran `npm run typecheck` which completed successfully.
- Ran `cd src-tauri && cargo check` which failed in this container due to a missing system `glib-2.0` development package and is unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7ce19b908325b9a40a7e6d82ec07)