### PR TITLE
fix: windows threads and terminal

### DIFF
--- a/src/features/threads/utils/threadNormalize.test.ts
+++ b/src/features/threads/utils/threadNormalize.test.ts
@@ -36,8 +36,8 @@ describe("normalizeRootPath", () => {
   });
 
   it("normalizes Windows drive-letter paths case-insensitively", () => {
-    expect(normalizeRootPath("C:\\Dev\\Repo\\")).toBe("c:/Dev/Repo");
-    expect(normalizeRootPath("c:/Dev/Repo")).toBe("c:/Dev/Repo");
+    expect(normalizeRootPath("C:\\Dev\\Repo\\")).toBe("c:/dev/repo");
+    expect(normalizeRootPath("c:/Dev/Repo")).toBe("c:/dev/repo");
   });
 
   it("normalizes UNC paths case-insensitively", () => {

--- a/src/features/threads/utils/threadNormalize.ts
+++ b/src/features/threads/utils/threadNormalize.ts
@@ -38,7 +38,7 @@ export function normalizeRootPath(value: string) {
     return "";
   }
   if (/^[A-Za-z]:\//.test(normalized)) {
-    return `${normalized.charAt(0).toLowerCase()}${normalized.slice(1)}`;
+    return normalized.toLowerCase();
   }
   if (normalized.startsWith("//")) {
     return normalized.toLowerCase();


### PR DESCRIPTION
Fixed with the last version. Threads are refreshing properly getting all the threads from codex/vs code. Also terminal working