### PR TITLE
fix(terminal): renumber auto-named tabs to prevent duplicate labels

### DIFF
--- a/src/features/terminal/hooks/useTerminalTabs.test.tsx
+++ b/src/features/terminal/hooks/useTerminalTabs.test.tsx
@@ -35,3 +35,95 @@ describe("useTerminalTabs.ensureTerminalWithTitle", () => {
     ]);
   });
 });
+
+describe("useTerminalTabs auto-named tabs", () => {
+  it("renumbers remaining auto-named tabs after closing one", () => {
+    const { result } = renderHook(() =>
+      useTerminalTabs({ activeWorkspaceId: "workspace-1" }),
+    );
+
+    let firstId = "";
+    let secondId = "";
+    act(() => {
+      firstId = result.current.createTerminal("workspace-1");
+      secondId = result.current.createTerminal("workspace-1");
+    });
+
+    act(() => {
+      result.current.closeTerminal("workspace-1", firstId);
+    });
+
+    expect(result.current.terminals).toEqual([
+      { id: secondId, title: "Terminal 1" },
+    ]);
+  });
+
+  it("does not create duplicate auto-named labels after close and create", () => {
+    const { result } = renderHook(() =>
+      useTerminalTabs({ activeWorkspaceId: "workspace-1" }),
+    );
+
+    let firstId = "";
+    let secondId = "";
+    let thirdId = "";
+    act(() => {
+      firstId = result.current.createTerminal("workspace-1");
+      secondId = result.current.createTerminal("workspace-1");
+    });
+
+    act(() => {
+      result.current.closeTerminal("workspace-1", firstId);
+    });
+
+    act(() => {
+      thirdId = result.current.createTerminal("workspace-1");
+    });
+
+    expect(result.current.terminals).toEqual([
+      { id: secondId, title: "Terminal 1" },
+      { id: thirdId, title: "Terminal 2" },
+    ]);
+  });
+
+  it("keeps custom titles while numbering auto-named tabs independently", () => {
+    const { result } = renderHook(() =>
+      useTerminalTabs({ activeWorkspaceId: "workspace-1" }),
+    );
+
+    let firstAutoId = "";
+    let secondAutoId = "";
+    act(() => {
+      result.current.ensureTerminalWithTitle("workspace-1", "launch", "Launch");
+      firstAutoId = result.current.createTerminal("workspace-1");
+      secondAutoId = result.current.createTerminal("workspace-1");
+    });
+
+    expect(result.current.terminals).toEqual([
+      { id: "launch", title: "Launch" },
+      { id: firstAutoId, title: "Terminal 1" },
+      { id: secondAutoId, title: "Terminal 2" },
+    ]);
+  });
+
+  it("converts an auto-named tab to custom and renumbers remaining auto tabs", () => {
+    const { result } = renderHook(() =>
+      useTerminalTabs({ activeWorkspaceId: "workspace-1" }),
+    );
+
+    let firstAutoId = "";
+    let secondAutoId = "";
+    act(() => {
+      firstAutoId = result.current.createTerminal("workspace-1");
+      secondAutoId = result.current.createTerminal("workspace-1");
+    });
+
+    act(() => {
+      result.current.ensureTerminalWithTitle("workspace-1", firstAutoId, "Launch");
+    });
+
+    expect(result.current.terminals).toEqual([
+      { id: firstAutoId, title: "Launch" },
+      { id: secondAutoId, title: "Terminal 1" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem
<img width="441" height="171" alt="Screenshot 2026-02-16 at 2 47 40 PM" src="https://github.com/user-attachments/assets/b24aff73-0d1d-48ee-b823-3521ef9687f4" />

## Summary
- Reindex auto-created terminal tab labels after create/close so labels stay contiguous (`Terminal 1..N`).
- Preserve custom terminal tab titles (for example `Launch`, `Setup`) while only renumbering auto-generated tabs.
- Keep the public `TerminalTab` API unchanged and track auto-named behavior with internal hook metadata.
- Add regression tests for close reindexing, duplicate prevention after close+create, mixed custom/auto tabs, and auto-to-custom conversion.



## Testing
- `npm run test -- src/features/terminal/hooks/useTerminalTabs.test.tsx`
- `npm run test`
- `npm run typecheck` (currently fails on pre-existing unrelated `GitLogEntry.refs` errors in git/review files)

