### PR TITLE
perf: bypass React render cycle during panel resize drag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,6 +273,8 @@ function MainApp() {
     activeWorkspaceId,
   });
   const {
+    appRef,
+    isResizing,
     sidebarWidth,
     chatDiffSplitPositionPercent,
     rightPanelWidth,
@@ -2435,7 +2437,7 @@ function MainApp() {
   );
 
   return (
-    <div className={appClassName} style={appStyle}>
+    <div className={`${appClassName}${isResizing ? " is-resizing" : ""}`} style={appStyle} ref={appRef}>
       <div className="drag-strip" id="titlebar" data-tauri-drag-region />
       <TitlebarExpandControls {...sidebarToggleProps} />
       {shouldLoadGitHubPanelData ? (

--- a/src/features/app/hooks/useLayoutController.ts
+++ b/src/features/app/hooks/useLayoutController.ts
@@ -18,6 +18,8 @@ export function useLayoutController({
   toggleTerminalShortcut: string | null;
 }) {
   const {
+    appRef,
+    isResizing,
     sidebarWidth,
     rightPanelWidth,
     chatDiffSplitPositionPercent,
@@ -67,6 +69,8 @@ export function useLayoutController({
   });
 
   return {
+    appRef,
+    isResizing,
     layoutMode,
     isCompact,
     isTablet,

--- a/src/features/layout/hooks/useResizablePanels.test.ts
+++ b/src/features/layout/hooks/useResizablePanels.test.ts
@@ -88,11 +88,15 @@ describe("useResizablePanels", () => {
 
   it("persists sidebar width changes and clamps max", () => {
     const hook = renderResizablePanels();
+    const appEl = document.createElement("div");
+    document.body.appendChild(appEl);
+    hook.result.appRef.current = appEl;
 
     act(() => {
       hook.result.onSidebarResizeStart({
         clientX: 0,
         clientY: 0,
+        preventDefault() {},
       } as React.MouseEvent);
     });
 
@@ -102,27 +106,32 @@ describe("useResizablePanels", () => {
       );
     });
 
+    act(() => {
+      window.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
     expect(hook.result.sidebarWidth).toBe(420);
     expect(window.localStorage.getItem("codexmonitor.sidebarWidth")).toBe(
       "420",
     );
 
-    act(() => {
-      window.dispatchEvent(new MouseEvent("mouseup"));
-    });
-
     hook.unmount();
+    appEl.remove();
   });
 
   it("moves split position right when dragging the splitter right", () => {
     const hook = renderResizablePanels();
     const { split, resizer } = buildSplitDom();
+    const appEl = document.createElement("div");
+    document.body.appendChild(appEl);
+    hook.result.appRef.current = appEl;
 
     act(() => {
       hook.result.onChatDiffSplitPositionResizeStart({
         clientX: 500,
         clientY: 0,
         currentTarget: resizer,
+        preventDefault() {},
       } as unknown as React.MouseEvent);
     });
 
@@ -132,25 +141,30 @@ describe("useResizablePanels", () => {
       );
     });
 
-    expect(hook.result.chatDiffSplitPositionPercent).toBe(75);
-
     act(() => {
       window.dispatchEvent(new MouseEvent("mouseup"));
     });
 
+    expect(hook.result.chatDiffSplitPositionPercent).toBe(75);
+
     hook.unmount();
     split.remove();
+    appEl.remove();
   });
 
   it("moves split position left when dragging the splitter left", () => {
     const hook = renderResizablePanels();
     const { split, resizer } = buildSplitDom();
+    const appEl = document.createElement("div");
+    document.body.appendChild(appEl);
+    hook.result.appRef.current = appEl;
 
     act(() => {
       hook.result.onChatDiffSplitPositionResizeStart({
         clientX: 500,
         clientY: 0,
         currentTarget: resizer,
+        preventDefault() {},
       } as unknown as React.MouseEvent);
     });
 
@@ -160,13 +174,14 @@ describe("useResizablePanels", () => {
       );
     });
 
-    expect(hook.result.chatDiffSplitPositionPercent).toBe(25);
-
     act(() => {
       window.dispatchEvent(new MouseEvent("mouseup"));
     });
 
+    expect(hook.result.chatDiffSplitPositionPercent).toBe(25);
+
     hook.unmount();
     split.remove();
+    appEl.remove();
   });
 });

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -60,6 +60,11 @@ body {
   font-family: var(--ui-font-family);
 }
 
+.app.is-resizing,
+.app.is-resizing .main {
+  transition: none;
+}
+
 .drag-strip {
   position: absolute;
   top: 0;


### PR DESCRIPTION
 ## Summary
  - During resize drag, CSS variables are now written directly to the DOM instead of calling `setState` on every mousemove, eliminating hundreds of React re-renders per drag
  - Disables CSS grid transitions while dragging via an `is-resizing` class
  - Prevents text selection flash during drag via `preventDefault` on `mousedown`
  - React state and localStorage sync once on mouseup

### Testing

- Drag each resizer (sidebar, right panel, plan, terminal, debug, chat/diff split). Handle should track cursor with no visible lag
- Release drag, reload page: confirm widths persist
- Existing text selections should remain duringn resize

### Before

https://github.com/user-attachments/assets/19ae591a-2eb7-49a5-bc5a-a6f7c95fde05

### After

https://github.com/user-attachments/assets/d72e3282-0ac7-4564-a6d4-86f9fdcd7bcc