### PR TITLE
chore(wt): copy iOS local tauri config into new worktrees

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,8 @@
+# Worktrunk project config for codex-monitor
+# Docs: https://worktrunk.dev/config/
+
+[post-create]
+# Fast-start new worktrees by copying selected gitignored files from primary.
+copy = "wt step copy-ignored"
+# Ensure local iOS signing/config follows every new worktree.
+copy_tauri_ios_local_conf = "if [ -f \"../{{ repo }}/src-tauri/tauri.ios.local.conf.json\" ]; then cp \"../{{ repo }}/src-tauri/tauri.ios.local.conf.json\" \"src-tauri/tauri.ios.local.conf.json\"; fi"


### PR DESCRIPTION
## Summary
- add project `wt` post-create hooks in `.config/wt.toml`
- keep `wt step copy-ignored` fast-start behavior
- add explicit `copy_tauri_ios_local_conf` hook to copy `src-tauri/tauri.ios.local.conf.json` from primary worktree into newly created worktrees

## Why
New worktrees need local iOS Tauri config to build/run in simulator without manual copy each time.

## Validation
- created a test worktree via `wt switch -c test/wt-ios-conf-copy-1771865619`
- confirmed file exists in new worktree:
  - `src-tauri/tauri.ios.local.conf.json`
