### PR TITLE
fix: scope Linux WebKit compositing workaround to X11

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,8 +82,10 @@ pub fn run() {
         {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
+        let is_x11 = !is_wayland && std::env::var_os("DISPLAY").is_some();
         // Work around sporadic blank WebKitGTK renders on X11 by disabling compositing mode.
-        if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+        // Keep Wayland untouched because this can interfere with input behavior on some setups.
+        if is_x11 && std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
         }
     }


### PR DESCRIPTION
## Summary
- limit the Linux `WEBKIT_DISABLE_COMPOSITING_MODE=1` workaround to X11 sessions only
- keep Wayland sessions untouched to avoid IME/input regressions in WebKitGTK
- no frontend dictation shortcut behavior changes in this PR

## Why
This PR narrows the Linux `WEBKIT_DISABLE_COMPOSITING_MODE=1` workaround to X11 sessions only.
The setting helps with sporadic blank WebKitGTK renders on X11, but on some Wayland setups (for example, with Fcitx5) it can interfere with IME input/composition behavior in WebKitGTK.

## Change
- detect X11 as `!is_wayland && DISPLAY`
- only set `WEBKIT_DISABLE_COMPOSITING_MODE` when running on X11

## Validation
- `npm run typecheck` ✅
- `npm run test` ✅
- `cd src-tauri && cargo check` ✅ (warnings only)
