### PR TITLE
fix: resolve and bundle daemon binary on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY="$(cat "$HOME/.tauri/codexmonitor.key")"
           npm run tauri -- build --bundles app
 
+      - name: Build daemon binaries
+        run: |
+          set -euo pipefail
+          cd src-tauri
+          cargo build --release --bin codex_monitor_daemon --bin codex_monitor_daemonctl
+
       - name: Bundle OpenSSL and re-sign
         run: |
           set -euo pipefail

--- a/scripts/build_run_ios_device.sh
+++ b/scripts/build_run_ios_device.sh
@@ -205,11 +205,17 @@ fi
 
 if [[ "$SKIP_BUILD" -eq 0 ]]; then
   sync_ios_icons
+  BUILD_CMD=("$NPM_BIN" run tauri -- ios build -d -t "$TARGET")
+  if [[ ${#TAURI_CONFIG_ARGS[@]} -gt 0 ]]; then
+    BUILD_CMD+=("${TAURI_CONFIG_ARGS[@]}")
+  fi
   if [[ "$OPEN_XCODE" -eq 1 ]]; then
-    "$NPM_BIN" run tauri -- ios build -d -t "$TARGET" "${TAURI_CONFIG_ARGS[@]}" --open
+    BUILD_CMD+=(--open)
+    "${BUILD_CMD[@]}"
     exit 0
   fi
-  "$NPM_BIN" run tauri -- ios build -d -t "$TARGET" "${TAURI_CONFIG_ARGS[@]}" --ci
+  BUILD_CMD+=(--ci)
+  "${BUILD_CMD[@]}"
 fi
 
 APP_PATH="src-tauri/gen/apple/build/arm64/Codex Monitor.app"

--- a/scripts/macos-fix-openssl.sh
+++ b/scripts/macos-fix-openssl.sh
@@ -47,6 +47,29 @@ frameworks_dir="${app_path}/Contents/Frameworks"
 bin_path="${app_path}/Contents/MacOS/codex-monitor"
 daemon_path="${app_path}/Contents/MacOS/codex_monitor_daemon"
 daemonctl_path="${app_path}/Contents/MacOS/codex_monitor_daemonctl"
+daemon_source="${DAEMON_BINARY_PATH:-src-tauri/target/release/codex_monitor_daemon}"
+daemonctl_source="${DAEMONCTL_BINARY_PATH:-src-tauri/target/release/codex_monitor_daemonctl}"
+
+copy_if_missing() {
+  local source_path="$1"
+  local destination_path="$2"
+  local label="$3"
+
+  if [[ -f "${destination_path}" ]]; then
+    return
+  fi
+
+  if [[ -f "${source_path}" ]]; then
+    cp -f "${source_path}" "${destination_path}"
+    chmod +x "${destination_path}"
+    echo "Bundled ${label} binary from ${source_path}"
+  else
+    echo "Warning: ${label} binary not found in app or at ${source_path}"
+  fi
+}
+
+copy_if_missing "${daemon_source}" "${daemon_path}" "daemon"
+copy_if_missing "${daemonctl_source}" "${daemonctl_path}" "daemonctl"
 
 if [[ ! -f "${libssl}" || ! -f "${libcrypto}" ]]; then
   echo "OpenSSL dylibs not found at ${openssl_prefix}/lib"

--- a/src-tauri/src/daemon_binary.rs
+++ b/src-tauri/src/daemon_binary.rs
@@ -8,24 +8,84 @@ pub(crate) fn daemon_binary_candidates() -> &'static [&'static str] {
     }
 }
 
+fn daemon_search_dirs(executable_dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    let mut push_unique = |path: PathBuf| {
+        if !dirs.iter().any(|entry| entry == &path) {
+            dirs.push(path);
+        }
+    };
+
+    push_unique(executable_dir.to_path_buf());
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(contents_dir) = executable_dir.parent() {
+            push_unique(contents_dir.join("Resources"));
+        }
+        push_unique(PathBuf::from("/opt/homebrew/bin"));
+        push_unique(PathBuf::from("/usr/local/bin"));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        push_unique(PathBuf::from("/usr/local/bin"));
+        push_unique(PathBuf::from("/usr/bin"));
+        push_unique(PathBuf::from("/usr/sbin"));
+    }
+
+    dirs
+}
+
 pub(crate) fn resolve_daemon_binary_path() -> Result<PathBuf, String> {
+    let mut attempted_paths: Vec<PathBuf> = Vec::new();
     let current_exe = std::env::current_exe().map_err(|err| err.to_string())?;
     let parent = current_exe
         .parent()
         .ok_or_else(|| "Unable to resolve executable directory".to_string())?;
     let candidate_names = daemon_binary_candidates();
 
-    for name in candidate_names {
-        let candidate = parent.join(name);
-        if candidate.is_file() {
-            return Ok(candidate);
+    if let Ok(explicit_raw) = std::env::var("CODEX_MONITOR_DAEMON_PATH") {
+        let explicit = explicit_raw.trim();
+        if !explicit.is_empty() {
+            let explicit_path = PathBuf::from(explicit);
+            if explicit_path.is_file() {
+                return Ok(explicit_path);
+            }
+            if explicit_path.is_dir() {
+                for name in candidate_names {
+                    let candidate = explicit_path.join(name);
+                    if candidate.is_file() {
+                        return Ok(candidate);
+                    }
+                    attempted_paths.push(candidate);
+                }
+            } else {
+                attempted_paths.push(explicit_path);
+            }
         }
     }
 
+    for search_dir in daemon_search_dirs(parent) {
+        for name in candidate_names {
+            let candidate = search_dir.join(name);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+            attempted_paths.push(candidate);
+        }
+    }
+
+    let attempted = attempted_paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
     Err(format!(
-        "Unable to locate daemon binary in {} (tried: {})",
-        parent.display(),
-        candidate_names.join(", ")
+        "Unable to locate daemon binary (tried: {})",
+        attempted
     ))
 }
 


### PR DESCRIPTION
## Summary
- fix daemon binary discovery in the desktop app by expanding search paths in `resolve_daemon_binary_path`
  - support explicit override via `CODEX_MONITOR_DAEMON_PATH`
  - search app `Contents/MacOS` (existing behavior)
  - on macOS, also search app `Contents/Resources`
  - on macOS, also search `/opt/homebrew/bin` and `/usr/local/bin`
- ensure release artifacts include daemon binaries during macOS packaging
  - build `codex_monitor_daemon` and `codex_monitor_daemonctl` in the release workflow before re-sign/notarize steps
  - in `scripts/macos-fix-openssl.sh`, copy missing daemon binaries from `src-tauri/target/release/*` into `Contents/MacOS` before signing
- fix `scripts/build_run_ios_device.sh` failure with `set -u` when optional `TAURI_CONFIG_ARGS` are empty

## Why
Users can hit:

```
Unable to locate daemon binary in /Applications/CodexMonitor.app/Contents/MacOS (tried: codex_monitor_daemon, codex-monitor-daemon)
```

because bundled `.app` artifacts may contain `codex_monitor_daemonctl` but not `codex_monitor_daemon`, and runtime lookup previously only searched one directory.

## Validation
- `npm run typecheck` ✅
- `cd src-tauri && cargo check` ✅

## Notes
This keeps existing binary name compatibility (`codex_monitor_daemon` and `codex-monitor-daemon`) while improving runtime resilience and release packaging determinism.
