### PR TITLE
fix(skills): reliably discover workspace project skills from `<workspace>/.agents/skills`

### DIFF
--- a/src-tauri/src/shared/codex_core.rs
+++ b/src-tauri/src/shared/codex_core.rs
@@ -698,10 +698,35 @@ pub(crate) async fn skills_list_core(
 ) -> Result<Value, String> {
     let session = get_session_clone(sessions, &workspace_id).await?;
     let workspace_path = resolve_workspace_path_core(workspaces, &workspace_id).await?;
-    let params = json!({ "cwd": workspace_path });
-    session
+
+    // Codex can discover project-scoped skills from `<workspace>/.agents/skills`.
+    // Some environments don't surface those reliably in CodexMonitor unless we
+    // pass the default project skills path explicitly.
+    let mut source_paths: Vec<String> = vec![];
+    let project_skills_dir = Path::new(&workspace_path).join(".agents").join("skills");
+    if project_skills_dir.is_dir() {
+        if let Some(p) = project_skills_dir.to_str() {
+            source_paths.push(p.to_string());
+        }
+    }
+
+    let params = if source_paths.is_empty() {
+        json!({ "cwd": workspace_path })
+    } else {
+        json!({ "cwd": workspace_path, "skillsPaths": source_paths })
+    };
+
+    let mut response = session
         .send_request_for_workspace(&workspace_id, "skills/list", params)
-        .await
+        .await?;
+
+    // Attach diagnostics for the UI (non-breaking: keep original response fields).
+    if let Value::Object(ref mut obj) = response {
+        obj.insert("sourcePaths".to_string(), json!(source_paths));
+        obj.insert("sourceErrors".to_string(), json!([]));
+    }
+
+    Ok(response)
 }
 
 pub(crate) async fn apps_list_core(


### PR DESCRIPTION
# PR Draft: �޸� CodexMonitor ��Ŀ�� Skills ʶ��Ĭ�� workspace Լ��·����

## Title
fix(skills): reliably discover workspace project skills from `<workspace>/.agents/skills`

## Problem
CodexMonitor �ڲ��ֳ������޷��ȶ�ʶ����Ŀ�� skills������ `$` �Զ���ȫȱʧ���� Codex CLI/app-server ʵ�ʿɶ�ȡ��Щ skills��

## Scope
�� PR ���޸���Ĭ����ĿԼ��·����ʶ�����⣬�������Զ��� skills ·�����á�

## What changed
1. ��� skill source ��������Ϊ workspace Լ��·����`<workspace>/.agents/skills`��  
2. `skills/list` ��Ӧ�ڼ���ԭ�ṹ�����ϣ�ͳһ���أ�  
   - �ϲ���� `skills`  
   - ����ֶ� `sourcePaths` / `sourceErrors`������������ɹ۲��ԣ�  
3. ǰ�� `useSkills` �����¾� response shape������ source �������� debug ����  
4. �л� workspace ���¼�ˢ��·���£������б����ǰ workspace ��ȷ���¡�

## Non-goals
- ������ `skillsPaths` ������
- ���ı�ȫ�ּ��ܻ���

## Validation
- `npm run typecheck` ?
- `npm run test` ?
- Rust side `cargo check` ?��������֤ͨ����

## User impact
- ��Ŀ�� `.agents/skills` �� skills ���ȶ���ʾ�� `$` �Զ���ȫ��
- �� workspace �л�ʱ���ܸ�����ȷ��
- ����·������ʱ��ֱ��ͨ�� diagnostics ��λԭ��

## Risk
�͵��У���Ҫ�� `skills/list` �ϲ�������߼�������ͨ������� response ����·�������ͻع���ա�

## Follow-up
�������֧���û��Զ��� skill source�����ڴ˻����ϵ����᰸�����뱾�޸���ϡ�

Related issue: #521