### PR TITLE
fix(skills): reliably discover project skills from <workspace>/.agents/skills

### DIFF
--- a/src-tauri/src/shared/codex_core.rs
+++ b/src-tauri/src/shared/codex_core.rs
@@ -698,10 +698,35 @@ pub(crate) async fn skills_list_core(
 ) -> Result<Value, String> {
     let session = get_session_clone(sessions, &workspace_id).await?;
     let workspace_path = resolve_workspace_path_core(workspaces, &workspace_id).await?;
-    let params = json!({ "cwd": workspace_path });
-    session
+
+    // Codex can discover project-scoped skills from `<workspace>/.agents/skills`.
+    // Some environments don't surface those reliably in CodexMonitor unless we
+    // pass the default project skills path explicitly.
+    let mut source_paths: Vec<String> = vec![];
+    let project_skills_dir = Path::new(&workspace_path).join(".agents").join("skills");
+    if project_skills_dir.is_dir() {
+        if let Some(p) = project_skills_dir.to_str() {
+            source_paths.push(p.to_string());
+        }
+    }
+
+    let params = if source_paths.is_empty() {
+        json!({ "cwd": workspace_path })
+    } else {
+        json!({ "cwd": workspace_path, "skillsPaths": source_paths })
+    };
+
+    let mut response = session
         .send_request_for_workspace(&workspace_id, "skills/list", params)
-        .await
+        .await?;
+
+    // Attach diagnostics for the UI (non-breaking: keep original response fields).
+    if let Value::Object(ref mut obj) = response {
+        obj.insert("sourcePaths".to_string(), json!(source_paths));
+        obj.insert("sourceErrors".to_string(), json!([]));
+    }
+
+    Ok(response)
 }
 
 pub(crate) async fn apps_list_core(


### PR DESCRIPTION
## Problem
CodexMonitor does not reliably surface project-scoped skills located under `<workspace>/.agents/skills` (skills list and `$` autocomplete can be missing/stale).

## Change
- For the `skills/list` request, include the default project skills path `<workspace>/.agents/skills` (when it exists).
- Attach non-breaking diagnostics fields (`sourcePaths`, `sourceErrors`) to help debug discovery.

## Scope
This is intended to be a minimal, backwards-compatible change focused on improving default project-skill discovery. It does not remove or change existing user-configurable skill path behavior.

## Validation
- Manual: verified that skills under `.agents/skills` appear consistently after the change.\n\nRelated issue: #523