### PR TITLE
fix: focus paths textbox after selecting recent path

### DIFF
--- a/src/features/workspaces/components/MobileRemoteWorkspacePrompt.test.tsx
+++ b/src/features/workspaces/components/MobileRemoteWorkspacePrompt.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MobileRemoteWorkspacePrompt } from "./MobileRemoteWorkspacePrompt";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MobileRemoteWorkspacePrompt", () => {
+  it("focuses paths textarea and moves caret to end after selecting a recent path", async () => {
+    const recentPath = "/Users/vlad/dev/codex-monitor/cm";
+    function PromptHarness() {
+      const [value, setValue] = useState("");
+      return (
+        <MobileRemoteWorkspacePrompt
+          value={value}
+          error={null}
+          recentPaths={[recentPath]}
+          onChange={setValue}
+          onRecentPathSelect={(path) => {
+            setValue((prev) => (prev.length > 0 ? `${prev}\n${path}` : path));
+          }}
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      );
+    }
+    render(<PromptHarness />);
+
+    const recentPathButton = screen.getByRole("button", { name: recentPath });
+    fireEvent.click(recentPathButton);
+
+    const textarea = screen.getByLabelText("Paths");
+    await waitFor(() => {
+      expect(document.activeElement).toBe(textarea);
+      const expectedPosition = recentPath.length;
+      expect((textarea as HTMLTextAreaElement).selectionStart).toBe(expectedPosition);
+      expect((textarea as HTMLTextAreaElement).selectionEnd).toBe(expectedPosition);
+    });
+  });
+});

--- a/src/features/workspaces/components/MobileRemoteWorkspacePrompt.tsx
+++ b/src/features/workspaces/components/MobileRemoteWorkspacePrompt.tsx
@@ -21,9 +21,18 @@ export function MobileRemoteWorkspacePrompt({
   onConfirm,
 }: MobileRemoteWorkspacePromptProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const focusTextareaAtEnd = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    textarea.focus();
+    const end = textarea.value.length;
+    textarea.setSelectionRange(end, end);
+  };
 
   useEffect(() => {
-    textareaRef.current?.focus();
+    focusTextareaAtEnd();
   }, []);
 
   return (
@@ -63,7 +72,12 @@ export function MobileRemoteWorkspacePrompt({
                   key={path}
                   type="button"
                   className="mobile-remote-workspace-modal-recent-item"
-                  onClick={() => onRecentPathSelect(path)}
+                  onClick={() => {
+                    onRecentPathSelect(path);
+                    requestAnimationFrame(() => {
+                      focusTextareaAtEnd();
+                    });
+                  }}
                 >
                   {path}
                 </button>


### PR DESCRIPTION
## Summary
- keep existing recent-path append behavior unchanged
- after selecting a recent path, move focus to the paths textarea and place the caret at the end
- add a jsdom test that covers focus and caret placement after recent-path click

## Validation
- npm run test -- src/features/workspaces/components/MobileRemoteWorkspacePrompt.test.tsx
- npm run typecheck
