### PR TITLE
Add settings sync mode and collapsible subagent sessions

### DIFF
--- a/src-tauri/src/shared/settings_core.rs
+++ b/src-tauri/src/shared/settings_core.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
+use serde_json::Value;
 use tokio::sync::Mutex;
 
 use crate::codex::config as codex_config;
-use crate::storage::write_settings;
-use crate::types::AppSettings;
+use crate::storage::{read_settings, write_settings};
+use crate::types::{AppSettings, SettingsSyncMode};
 
 fn normalize_personality(value: &str) -> Option<&'static str> {
     match value.trim() {
@@ -16,25 +17,27 @@ fn normalize_personality(value: &str) -> Option<&'static str> {
 
 pub(crate) async fn get_app_settings_core(app_settings: &Mutex<AppSettings>) -> AppSettings {
     let mut settings = app_settings.lock().await.clone();
-    if let Ok(Some(collaboration_modes_enabled)) = codex_config::read_collaboration_modes_enabled()
-    {
-        settings.collaboration_modes_enabled = collaboration_modes_enabled;
-    }
-    if let Ok(Some(steer_enabled)) = codex_config::read_steer_enabled() {
-        settings.steer_enabled = steer_enabled;
-    }
-    if let Ok(Some(unified_exec_enabled)) = codex_config::read_unified_exec_enabled() {
-        settings.unified_exec_enabled = unified_exec_enabled;
-    }
-    if let Ok(Some(apps_enabled)) = codex_config::read_apps_enabled() {
-        settings.experimental_apps_enabled = apps_enabled;
-    }
-    if let Ok(personality) = codex_config::read_personality() {
-        settings.personality = personality
-            .as_deref()
-            .and_then(normalize_personality)
-            .unwrap_or("friendly")
-            .to_string();
+    if matches!(settings.sync_mode, SettingsSyncMode::Bidirectional) {
+        if let Ok(Some(collaboration_modes_enabled)) = codex_config::read_collaboration_modes_enabled()
+        {
+            settings.collaboration_modes_enabled = collaboration_modes_enabled;
+        }
+        if let Ok(Some(steer_enabled)) = codex_config::read_steer_enabled() {
+            settings.steer_enabled = steer_enabled;
+        }
+        if let Ok(Some(unified_exec_enabled)) = codex_config::read_unified_exec_enabled() {
+            settings.unified_exec_enabled = unified_exec_enabled;
+        }
+        if let Ok(Some(apps_enabled)) = codex_config::read_apps_enabled() {
+            settings.experimental_apps_enabled = apps_enabled;
+        }
+        if let Ok(personality) = codex_config::read_personality() {
+            settings.personality = personality
+                .as_deref()
+                .and_then(normalize_personality)
+                .unwrap_or("friendly")
+                .to_string();
+        }
     }
     settings
 }
@@ -44,15 +47,86 @@ pub(crate) async fn update_app_settings_core(
     app_settings: &Mutex<AppSettings>,
     settings_path: &PathBuf,
 ) -> Result<AppSettings, String> {
-    let _ = codex_config::write_collaboration_modes_enabled(settings.collaboration_modes_enabled);
-    let _ = codex_config::write_steer_enabled(settings.steer_enabled);
-    let _ = codex_config::write_unified_exec_enabled(settings.unified_exec_enabled);
-    let _ = codex_config::write_apps_enabled(settings.experimental_apps_enabled);
-    let _ = codex_config::write_personality(settings.personality.as_str());
-    write_settings(settings_path, &settings)?;
+    let previous = app_settings.lock().await.clone();
+    let mut next = settings;
+
+    if matches!(next.sync_mode, SettingsSyncMode::Bidirectional) {
+        if let Ok(disk_settings) = read_settings(settings_path) {
+            next = merge_bidirectional_settings(previous.clone(), next, disk_settings)?;
+        }
+        reconcile_managed_config_fields(&previous, &mut next);
+    }
+
+    let _ = codex_config::write_collaboration_modes_enabled(next.collaboration_modes_enabled);
+    let _ = codex_config::write_steer_enabled(next.steer_enabled);
+    let _ = codex_config::write_unified_exec_enabled(next.unified_exec_enabled);
+    let _ = codex_config::write_apps_enabled(next.experimental_apps_enabled);
+    let _ = codex_config::write_personality(next.personality.as_str());
+    write_settings(settings_path, &next)?;
     let mut current = app_settings.lock().await;
-    *current = settings.clone();
-    Ok(settings)
+    *current = next.clone();
+    Ok(next)
+}
+
+fn merge_bidirectional_settings(
+    previous: AppSettings,
+    incoming: AppSettings,
+    disk: AppSettings,
+) -> Result<AppSettings, String> {
+    let previous_value = serde_json::to_value(previous).map_err(|e| e.to_string())?;
+    let incoming_value = serde_json::to_value(incoming.clone()).map_err(|e| e.to_string())?;
+    let disk_value = serde_json::to_value(disk).map_err(|e| e.to_string())?;
+
+    let mut merged = incoming_value.clone();
+    let (Value::Object(previous_map), Value::Object(incoming_map), Value::Object(disk_map), Value::Object(merged_map)) =
+        (&previous_value, &incoming_value, &disk_value, &mut merged)
+    else {
+        return Ok(incoming);
+    };
+
+    for (key, incoming_field) in incoming_map {
+        if let Some(previous_field) = previous_map.get(key) {
+            if incoming_field == previous_field {
+                if let Some(disk_field) = disk_map.get(key) {
+                    merged_map.insert(key.clone(), disk_field.clone());
+                }
+            }
+        }
+    }
+
+    serde_json::from_value(merged).map_err(|e| e.to_string())
+}
+
+fn reconcile_managed_config_fields(previous: &AppSettings, next: &mut AppSettings) {
+    if next.collaboration_modes_enabled == previous.collaboration_modes_enabled {
+        if let Ok(Some(value)) = codex_config::read_collaboration_modes_enabled() {
+            next.collaboration_modes_enabled = value;
+        }
+    }
+    if next.steer_enabled == previous.steer_enabled {
+        if let Ok(Some(value)) = codex_config::read_steer_enabled() {
+            next.steer_enabled = value;
+        }
+    }
+    if next.unified_exec_enabled == previous.unified_exec_enabled {
+        if let Ok(Some(value)) = codex_config::read_unified_exec_enabled() {
+            next.unified_exec_enabled = value;
+        }
+    }
+    if next.experimental_apps_enabled == previous.experimental_apps_enabled {
+        if let Ok(Some(value)) = codex_config::read_apps_enabled() {
+            next.experimental_apps_enabled = value;
+        }
+    }
+    if next.personality == previous.personality {
+        if let Ok(personality) = codex_config::read_personality() {
+            next.personality = personality
+                .as_deref()
+                .and_then(normalize_personality)
+                .unwrap_or("friendly")
+                .to_string();
+        }
+    }
 }
 
 pub(crate) fn get_codex_config_path_core() -> Result<String, String> {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -542,6 +542,13 @@ pub(crate) struct AppSettings {
     )]
     pub(crate) subagent_system_notifications_enabled: bool,
     #[serde(
+        default = "default_show_subagent_sessions",
+        rename = "showSubagentSessions"
+    )]
+    pub(crate) show_subagent_sessions: bool,
+    #[serde(default = "default_settings_sync_mode", rename = "syncMode")]
+    pub(crate) sync_mode: SettingsSyncMode,
+    #[serde(
         default = "default_collaboration_modes_enabled",
         rename = "collaborationModesEnabled"
     )]
@@ -651,6 +658,19 @@ pub(crate) enum BackendMode {
 impl Default for BackendMode {
     fn default() -> Self {
         default_backend_mode()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SettingsSyncMode {
+    AppAuthoritative,
+    Bidirectional,
+}
+
+impl Default for SettingsSyncMode {
+    fn default() -> Self {
+        SettingsSyncMode::AppAuthoritative
     }
 }
 
@@ -880,6 +900,14 @@ fn default_system_notifications_enabled() -> bool {
 
 fn default_subagent_system_notifications_enabled() -> bool {
     true
+}
+
+fn default_show_subagent_sessions() -> bool {
+    true
+}
+
+fn default_settings_sync_mode() -> SettingsSyncMode {
+    SettingsSyncMode::AppAuthoritative
 }
 
 fn default_split_chat_diff_view() -> bool {
@@ -1152,6 +1180,8 @@ impl Default for AppSettings {
             notification_sounds_enabled: true,
             system_notifications_enabled: true,
             subagent_system_notifications_enabled: true,
+            show_subagent_sessions: true,
+            sync_mode: SettingsSyncMode::AppAuthoritative,
             split_chat_diff_view: default_split_chat_diff_view(),
             preload_git_diffs: default_preload_git_diffs(),
             git_diff_ignore_whitespace_changes: default_git_diff_ignore_whitespace_changes(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Plus from "lucide-react/dist/esm/icons/plus";
 import RefreshCw from "lucide-react/dist/esm/icons/refresh-cw";
 import "./styles/base.css";
 import "./styles/ds-tokens.css";
@@ -219,6 +220,8 @@ function MainApp() {
     "home" | "projects" | "codex" | "git" | "log"
   >("codex");
   const [mobileThreadRefreshLoading, setMobileThreadRefreshLoading] = useState(false);
+  const [lastCodexWorkspaceId, setLastCodexWorkspaceId] = useState<string | null>(null);
+  const [lastCodexThreadId, setLastCodexThreadId] = useState<string | null>(null);
   const tabletTab =
     activeTab === "projects" || activeTab === "home" ? "codex" : activeTab;
   const {
@@ -689,6 +692,23 @@ function MainApp() {
     threadSortKey: threadListSortKey,
     onThreadCodexMetadataDetected: handleThreadCodexMetadataDetected,
   });
+
+  useEffect(() => {
+    if (!isPhone || !activeWorkspaceId) {
+      return;
+    }
+    setLastCodexWorkspaceId(activeWorkspaceId);
+  }, [activeWorkspaceId, isPhone]);
+
+  useEffect(() => {
+    if (!isPhone || !activeWorkspaceId || !activeThreadId) {
+      return;
+    }
+    const workspaceThreads = threadsByWorkspace[activeWorkspaceId] ?? [];
+    if (workspaceThreads.some((thread) => thread.id === activeThreadId)) {
+      setLastCodexThreadId(activeThreadId);
+    }
+  }, [activeThreadId, activeWorkspaceId, isPhone, threadsByWorkspace]);
   const { connectionState: remoteThreadConnectionState, reconnectLive } =
     useRemoteThreadLiveConnection({
       backendMode: appSettings.backendMode,
@@ -2036,6 +2056,8 @@ function MainApp() {
     Boolean(activeWorkspace) &&
     isCompact &&
     ((isPhone && activeTab === "codex") || (isTablet && tabletTab === "codex"));
+  const showPhoneCodexNewChatAction =
+    Boolean(activeWorkspace) && isCompact && isPhone && activeTab === "codex";
   const showMobilePollingFetchStatus =
     showCompactCodexThreadActions &&
     Boolean(activeWorkspace?.connected) &&
@@ -2090,6 +2112,7 @@ function MainApp() {
     pollingIntervalMs: REMOTE_THREAD_POLL_INTERVAL_MS,
     activeRateLimits,
     usageShowRemaining: appSettings.usageShowRemaining,
+    showSubagentSessions: appSettings.showSubagentSessions,
     accountInfo: activeAccount,
     onSwitchAccount: handleSwitchAccount,
     onCancelSwitchAccount: handleCancelSwitchAccount,
@@ -2193,6 +2216,22 @@ function MainApp() {
     launchScriptsState,
     mainHeaderActionsNode: (
       <>
+        {showPhoneCodexNewChatAction ? (
+          <button
+            type="button"
+            className="ghost main-header-action"
+            onClick={() => {
+              if (activeWorkspace) {
+                void handleAddAgent(activeWorkspace);
+              }
+            }}
+            data-tauri-drag-region="false"
+            aria-label="Start new chat in this workspace"
+            title="Start new chat in this workspace"
+          >
+            <Plus size={14} aria-hidden />
+          </button>
+        ) : null}
         {showCompactCodexThreadActions ? (
           <button
             type="button"
@@ -2236,6 +2275,18 @@ function MainApp() {
         clearDraftState();
         selectHome();
         return;
+      }
+      if (tab === "codex" && isPhone && !activeWorkspace && lastCodexWorkspaceId) {
+        const workspace = workspacesById.get(lastCodexWorkspaceId);
+        if (workspace) {
+          selectWorkspace(lastCodexWorkspaceId);
+          if (lastCodexThreadId) {
+            const workspaceThreads = threadsByWorkspace[lastCodexWorkspaceId] ?? [];
+            if (workspaceThreads.some((thread) => thread.id === lastCodexThreadId)) {
+              setActiveThreadId(lastCodexThreadId, lastCodexWorkspaceId);
+            }
+          }
+        }
       }
       setActiveTab(tab);
     },

--- a/src/features/app/components/PinnedThreadList.test.tsx
+++ b/src/features/app/components/PinnedThreadList.test.tsx
@@ -22,7 +22,7 @@ const statusMap = {
 };
 
 const baseProps = {
-  rows: [{ thread, depth: 0, workspaceId: "ws-1" }],
+  rows: [{ thread, depth: 0, hasChildren: false, workspaceId: "ws-1" }],
   activeWorkspaceId: "ws-1",
   activeThreadId: "thread-1",
   threadStatusById: statusMap,
@@ -76,8 +76,8 @@ describe("PinnedThreadList", () => {
       <PinnedThreadList
         {...baseProps}
         rows={[
-          { thread, depth: 0, workspaceId: "ws-1" },
-          { thread: otherThread, depth: 0, workspaceId: "ws-2" },
+          { thread, depth: 0, hasChildren: false, workspaceId: "ws-1" },
+          { thread: otherThread, depth: 0, hasChildren: false, workspaceId: "ws-2" },
         ]}
         onSelectThread={onSelectThread}
         onShowThreadMenu={onShowThreadMenu}
@@ -106,7 +106,7 @@ describe("PinnedThreadList", () => {
     const { container } = render(
       <PinnedThreadList
         {...baseProps}
-        rows={[{ thread: otherThread, depth: 0, workspaceId: "ws-2" }]}
+        rows={[{ thread: otherThread, depth: 0, hasChildren: false, workspaceId: "ws-2" }]}
         threadStatusById={{
           "thread-1": { isProcessing: false, hasUnread: false, isReviewing: true },
           "thread-2": { isProcessing: true, hasUnread: false, isReviewing: false },

--- a/src/features/app/components/PinnedThreadList.tsx
+++ b/src/features/app/components/PinnedThreadList.tsx
@@ -7,6 +7,7 @@ import { ThreadRow } from "./ThreadRow";
 type PinnedThreadRow = {
   thread: ThreadSummary;
   depth: number;
+  hasChildren: boolean;
   workspaceId: string;
 };
 
@@ -27,6 +28,8 @@ type PinnedThreadListProps = {
     threadId: string,
     canPin: boolean,
   ) => void;
+  collapsedThreadIdsByWorkspace?: Record<string, ReadonlySet<string>>;
+  onToggleThreadChildren?: (workspaceId: string, threadId: string) => void;
 };
 
 export function PinnedThreadList({
@@ -41,15 +44,18 @@ export function PinnedThreadList({
   isThreadPinned,
   onSelectThread,
   onShowThreadMenu,
+  collapsedThreadIdsByWorkspace,
+  onToggleThreadChildren,
 }: PinnedThreadListProps) {
   return (
     <div className="thread-list pinned-thread-list">
-      {rows.map(({ thread, depth, workspaceId }) => {
+      {rows.map(({ thread, depth, hasChildren, workspaceId }) => {
         return (
           <ThreadRow
             key={`${workspaceId}:${thread.id}`}
             thread={thread}
             depth={depth}
+            hasChildren={hasChildren}
             workspaceId={workspaceId}
             indentUnit={14}
             activeWorkspaceId={activeWorkspaceId}
@@ -62,6 +68,8 @@ export function PinnedThreadList({
             isThreadPinned={isThreadPinned}
             onSelectThread={onSelectThread}
             onShowThreadMenu={onShowThreadMenu}
+            isCollapsed={Boolean(collapsedThreadIdsByWorkspace?.[workspaceId]?.has(thread.id))}
+            onToggleThreadChildren={onToggleThreadChildren}
           />
         );
       })}

--- a/src/features/app/components/Sidebar.test.tsx
+++ b/src/features/app/components/Sidebar.test.tsx
@@ -34,6 +34,7 @@ const baseProps = {
   activeThreadId: null,
   accountRateLimits: null,
   usageShowRemaining: false,
+  showSubagentSessions: true,
   accountInfo: null,
   onSwitchAccount: vi.fn(),
   onCancelSwitchAccount: vi.fn(),
@@ -559,5 +560,48 @@ describe("Sidebar", () => {
 
     const indicator = screen.queryByTitle("Streaming updates in progress");
     expect(indicator).toBeNull();
+  });
+
+  it("can hide sub-agent sessions from the sidebar", () => {
+    render(
+      <Sidebar
+        {...baseProps}
+        showSubagentSessions={false}
+        workspaces={[
+          {
+            id: "ws-1",
+            name: "Workspace",
+            path: "/tmp/workspace",
+            connected: true,
+            settings: { sidebarCollapsed: false },
+          },
+        ]}
+        groupedWorkspaces={[
+          {
+            id: null,
+            name: "Workspaces",
+            workspaces: [
+              {
+                id: "ws-1",
+                name: "Workspace",
+                path: "/tmp/workspace",
+                connected: true,
+                settings: { sidebarCollapsed: false },
+              },
+            ],
+          },
+        ]}
+        threadsByWorkspace={{
+          "ws-1": [
+            { id: "thread-parent", name: "Parent", updatedAt: 2 },
+            { id: "thread-child", name: "Child", updatedAt: 1 },
+          ],
+        }}
+        threadParentById={{ "thread-child": "thread-parent" }}
+      />,
+    );
+
+    expect(screen.getByText("Parent")).toBeTruthy();
+    expect(screen.queryByText("Child")).toBeNull();
   });
 });

--- a/src/features/app/components/ThreadList.test.tsx
+++ b/src/features/app/components/ThreadList.test.tsx
@@ -24,7 +24,7 @@ const statusMap = {
 const baseProps = {
   workspaceId: "ws-1",
   pinnedRows: [],
-  unpinnedRows: [{ thread, depth: 0 }],
+  unpinnedRows: [{ thread, depth: 0, hasChildren: false }],
   totalThreadRoots: 1,
   isExpanded: false,
   nextCursor: null,
@@ -111,8 +111,8 @@ describe("ThreadList", () => {
         {...baseProps}
         nested
         unpinnedRows={[
-          { thread, depth: 0 },
-          { thread: nestedThread, depth: 1 },
+          { thread, depth: 0, hasChildren: true },
+          { thread: nestedThread, depth: 1, hasChildren: false },
         ]}
         onShowThreadMenu={onShowThreadMenu}
       />,

--- a/src/features/app/components/ThreadList.tsx
+++ b/src/features/app/components/ThreadList.tsx
@@ -7,6 +7,7 @@ import { ThreadRow } from "./ThreadRow";
 type ThreadListRow = {
   thread: ThreadSummary;
   depth: number;
+  hasChildren: boolean;
 };
 
 type ThreadListProps = {
@@ -35,6 +36,8 @@ type ThreadListProps = {
     threadId: string,
     canPin: boolean,
   ) => void;
+  collapsedThreadIds?: ReadonlySet<string>;
+  onToggleThreadChildren?: (workspaceId: string, threadId: string) => void;
 };
 
 export function ThreadList({
@@ -58,16 +61,19 @@ export function ThreadList({
   onLoadOlderThreads,
   onSelectThread,
   onShowThreadMenu,
+  collapsedThreadIds,
+  onToggleThreadChildren,
 }: ThreadListProps) {
   const indentUnit = nested ? 10 : 14;
 
   return (
     <div className={`thread-list${nested ? " thread-list-nested" : ""}`}>
-      {pinnedRows.map(({ thread, depth }) => (
+      {pinnedRows.map(({ thread, depth, hasChildren }) => (
         <ThreadRow
           key={thread.id}
           thread={thread}
           depth={depth}
+          hasChildren={hasChildren}
           workspaceId={workspaceId}
           indentUnit={indentUnit}
           activeWorkspaceId={activeWorkspaceId}
@@ -79,16 +85,19 @@ export function ThreadList({
           isThreadPinned={isThreadPinned}
           onSelectThread={onSelectThread}
           onShowThreadMenu={onShowThreadMenu}
+          isCollapsed={Boolean(collapsedThreadIds?.has(thread.id))}
+          onToggleThreadChildren={onToggleThreadChildren}
         />
       ))}
       {pinnedRows.length > 0 && unpinnedRows.length > 0 && (
         <div className="thread-list-separator" aria-hidden="true" />
       )}
-      {unpinnedRows.map(({ thread, depth }) => (
+      {unpinnedRows.map(({ thread, depth, hasChildren }) => (
         <ThreadRow
           key={thread.id}
           thread={thread}
           depth={depth}
+          hasChildren={hasChildren}
           workspaceId={workspaceId}
           indentUnit={indentUnit}
           activeWorkspaceId={activeWorkspaceId}
@@ -100,6 +109,8 @@ export function ThreadList({
           isThreadPinned={isThreadPinned}
           onSelectThread={onSelectThread}
           onShowThreadMenu={onShowThreadMenu}
+          isCollapsed={Boolean(collapsedThreadIds?.has(thread.id))}
+          onToggleThreadChildren={onToggleThreadChildren}
         />
       ))}
       {totalThreadRoots > 3 && (

--- a/src/features/app/components/ThreadRow.tsx
+++ b/src/features/app/components/ThreadRow.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, MouseEvent } from "react";
+import ChevronRight from "lucide-react/dist/esm/icons/chevron-right";
 
 import type { ThreadSummary } from "../../../types";
 import { getThreadStatusClass, type ThreadStatusById } from "../../../utils/threadStatus";
@@ -6,6 +7,8 @@ import { getThreadStatusClass, type ThreadStatusById } from "../../../utils/thre
 type ThreadRowProps = {
   thread: ThreadSummary;
   depth: number;
+  hasChildren?: boolean;
+  isCollapsed?: boolean;
   workspaceId: string;
   indentUnit: number;
   activeWorkspaceId: string | null;
@@ -23,11 +26,14 @@ type ThreadRowProps = {
     threadId: string,
     canPin: boolean,
   ) => void;
+  onToggleThreadChildren?: (workspaceId: string, threadId: string) => void;
 };
 
 export function ThreadRow({
   thread,
   depth,
+  hasChildren = false,
+  isCollapsed = false,
   workspaceId,
   indentUnit,
   activeWorkspaceId,
@@ -40,6 +46,7 @@ export function ThreadRow({
   isThreadPinned,
   onSelectThread,
   onShowThreadMenu,
+  onToggleThreadChildren,
 }: ThreadRowProps) {
   const relativeTime = getThreadTime(thread);
   const badge = getThreadArgsBadge?.(workspaceId, thread.id) ?? null;
@@ -82,6 +89,21 @@ export function ThreadRow({
         }
       }}
     >
+      {hasChildren && (
+        <button
+          type="button"
+          className={`thread-collapse-toggle${isCollapsed ? " collapsed" : ""}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleThreadChildren?.(workspaceId, thread.id);
+          }}
+          aria-label={isCollapsed ? "Expand sub-agent sessions" : "Collapse sub-agent sessions"}
+          aria-expanded={!isCollapsed}
+          data-tauri-drag-region="false"
+        >
+          <ChevronRight size={12} aria-hidden />
+        </button>
+      )}
       <span className={`thread-status ${statusClass}`} aria-hidden />
       {isPinned && <span className="thread-pin-icon" aria-label="Pinned">📌</span>}
       <span className="thread-name">{thread.name}</span>

--- a/src/features/app/components/WorktreeSection.test.tsx
+++ b/src/features/app/components/WorktreeSection.test.tsx
@@ -46,6 +46,7 @@ describe("WorktreeSection", () => {
         onShowWorktreeMenu={vi.fn()}
         onToggleExpanded={vi.fn()}
         onLoadOlderThreads={vi.fn()}
+        showSubagentSessions
       />,
     );
 

--- a/src/features/app/components/WorktreeSection.tsx
+++ b/src/features/app/components/WorktreeSection.tsx
@@ -8,8 +8,8 @@ import { ThreadLoading } from "./ThreadLoading";
 import { WorktreeCard } from "./WorktreeCard";
 
 type ThreadRowsResult = {
-  pinnedRows: Array<{ thread: ThreadSummary; depth: number }>;
-  unpinnedRows: Array<{ thread: ThreadSummary; depth: number }>;
+  pinnedRows: Array<{ thread: ThreadSummary; depth: number; hasChildren: boolean }>;
+  unpinnedRows: Array<{ thread: ThreadSummary; depth: number; hasChildren: boolean }>;
   totalRoots: number;
   hasMoreRoots: boolean;
 };
@@ -32,6 +32,10 @@ type WorktreeSectionProps = {
     workspaceId: string,
     getPinTimestamp: (workspaceId: string, threadId: string) => number | null,
     pinVersion?: number,
+    options?: {
+      showSubagentSessions?: boolean;
+      collapsedParentThreadIds?: ReadonlySet<string>;
+    },
   ) => ThreadRowsResult;
   getThreadTime: (thread: ThreadSummary) => string | null;
   getThreadArgsBadge?: (workspaceId: string, threadId: string) => string | null;
@@ -51,6 +55,9 @@ type WorktreeSectionProps = {
   onShowWorktreeMenu: (event: MouseEvent, worktree: WorkspaceInfo) => void;
   onToggleExpanded: (workspaceId: string) => void;
   onLoadOlderThreads: (workspaceId: string) => void;
+  showSubagentSessions: boolean;
+  collapsedThreadIdsByWorkspace?: Record<string, ReadonlySet<string>>;
+  onToggleThreadChildren?: (workspaceId: string, threadId: string) => void;
   sectionLabel?: string;
   sectionIcon?: ReactNode;
   className?: string;
@@ -82,6 +89,9 @@ export function WorktreeSection({
   onShowWorktreeMenu,
   onToggleExpanded,
   onLoadOlderThreads,
+  showSubagentSessions,
+  collapsedThreadIdsByWorkspace,
+  onToggleThreadChildren,
   sectionLabel = "Worktrees",
   sectionIcon,
   className,
@@ -119,6 +129,10 @@ export function WorktreeSection({
             worktree.id,
             getPinTimestamp,
             pinnedThreadsVersion,
+            {
+              showSubagentSessions,
+              collapsedParentThreadIds: collapsedThreadIdsByWorkspace?.[worktree.id],
+            },
           );
 
           return (
@@ -150,6 +164,8 @@ export function WorktreeSection({
                   getThreadTime={getThreadTime}
                   getThreadArgsBadge={getThreadArgsBadge}
                   isThreadPinned={isThreadPinned}
+                  collapsedThreadIds={collapsedThreadIdsByWorkspace?.[worktree.id]}
+                  onToggleThreadChildren={onToggleThreadChildren}
                   onToggleExpanded={onToggleExpanded}
                   onLoadOlderThreads={onLoadOlderThreads}
                   onSelectThread={onSelectThread}

--- a/src/features/app/hooks/useThreadRows.test.tsx
+++ b/src/features/app/hooks/useThreadRows.test.tsx
@@ -125,4 +125,35 @@ describe("useThreadRows", () => {
       ["thread-child", 1],
     ]);
   });
+
+  it("supports hiding and collapsing subagent rows", () => {
+    const threads: ThreadSummary[] = [
+      { id: "thread-root", name: "Root", updatedAt: 1 },
+      { id: "thread-child", name: "Child", updatedAt: 2 },
+    ];
+    const getPinTimestamp = vi.fn(() => null);
+    const { result } = renderHook(() =>
+      useThreadRows({ "thread-child": "thread-root" }),
+    );
+
+    const hidden = result.current.getThreadRows(
+      threads,
+      true,
+      "ws-1",
+      getPinTimestamp,
+      0,
+      { showSubagentSessions: false },
+    );
+    expect(hidden.unpinnedRows.map((row) => row.thread.id)).toEqual(["thread-root"]);
+
+    const collapsed = result.current.getThreadRows(
+      threads,
+      true,
+      "ws-1",
+      getPinTimestamp,
+      0,
+      { showSubagentSessions: true, collapsedParentThreadIds: new Set(["thread-root"]) },
+    );
+    expect(collapsed.unpinnedRows.map((row) => row.thread.id)).toEqual(["thread-root"]);
+  });
 });

--- a/src/features/app/hooks/useThreadRows.ts
+++ b/src/features/app/hooks/useThreadRows.ts
@@ -5,6 +5,7 @@ import type { ThreadSummary } from "../../../types";
 type ThreadRow = {
   thread: ThreadSummary;
   depth: number;
+  hasChildren: boolean;
 };
 
 type ThreadRowResult = {
@@ -17,6 +18,11 @@ type ThreadRowResult = {
 type ThreadRowCacheEntry = {
   pinVersion: number;
   result: ThreadRowResult;
+};
+
+type GetThreadRowsOptions = {
+  showSubagentSessions?: boolean;
+  collapsedParentThreadIds?: ReadonlySet<string>;
 };
 
 export function useThreadRows(threadParentById: Record<string, string>) {
@@ -42,8 +48,13 @@ export function useThreadRows(threadParentById: Record<string, string>) {
       workspaceId: string,
       getPinTimestamp: (workspaceId: string, threadId: string) => number | null,
       pinVersion = 0,
+      options?: GetThreadRowsOptions,
     ): ThreadRowResult => {
-      const cacheKey = `${workspaceId}:${isExpanded ? "1" : "0"}`;
+      const showSubagentSessions = options?.showSubagentSessions ?? true;
+      const collapsedKey = options?.collapsedParentThreadIds
+        ? [...options.collapsedParentThreadIds].sort().join(",")
+        : "";
+      const cacheKey = `${workspaceId}:${isExpanded ? "1" : "0"}:${showSubagentSessions ? "1" : "0"}:${collapsedKey}`;
       const threadCache = cacheRef.current.get(threads);
       const cachedEntry = threadCache?.get(cacheKey);
       if (cachedEntry && cachedEntry.pinVersion === pinVersion) {
@@ -105,8 +116,15 @@ export function useThreadRows(threadParentById: Record<string, string>) {
         depth: number,
         rows: ThreadRow[],
       ) => {
-        rows.push({ thread, depth });
         const children = childrenByParent.get(thread.id) ?? [];
+        const hasChildren = showSubagentSessions && children.length > 0;
+        rows.push({ thread, depth, hasChildren });
+        if (!showSubagentSessions) {
+          return;
+        }
+        if (options?.collapsedParentThreadIds?.has(thread.id)) {
+          return;
+        }
         children.forEach((child) => appendThread(child, depth + 1, rows));
       };
 

--- a/src/features/layout/hooks/layoutNodes/buildPrimaryNodes.tsx
+++ b/src/features/layout/hooks/layoutNodes/buildPrimaryNodes.tsx
@@ -56,6 +56,7 @@ export function buildPrimaryNodes(options: LayoutNodesOptions): PrimaryLayoutNod
       userInputRequests={options.userInputRequests}
       accountRateLimits={options.activeRateLimits}
       usageShowRemaining={options.usageShowRemaining}
+      showSubagentSessions={options.showSubagentSessions}
       accountInfo={options.accountInfo}
       onSwitchAccount={options.onSwitchAccount}
       onCancelSwitchAccount={options.onCancelSwitchAccount}

--- a/src/features/layout/hooks/layoutNodes/types.ts
+++ b/src/features/layout/hooks/layoutNodes/types.ts
@@ -129,6 +129,7 @@ export type LayoutNodesOptions = {
   pollingIntervalMs?: number;
   activeRateLimits: RateLimitSnapshot | null;
   usageShowRemaining: boolean;
+  showSubagentSessions: boolean;
   accountInfo: AccountSnapshot | null;
   onSwitchAccount: () => void;
   onCancelSwitchAccount: () => void;

--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -113,6 +113,8 @@ const baseSettings: AppSettings = {
   notificationSoundsEnabled: true,
   systemNotificationsEnabled: true,
   subagentSystemNotificationsEnabled: true,
+  showSubagentSessions: true,
+  syncMode: "app_authoritative",
   splitChatDiffView: false,
   preloadGitDiffs: true,
   gitDiffIgnoreWhitespaceChanges: false,
@@ -667,6 +669,45 @@ describe("SettingsView Display", () => {
     await waitFor(() => {
       expect(onUpdateAppSettings).toHaveBeenCalledWith(
         expect.objectContaining({ subagentSystemNotificationsEnabled: true }),
+      );
+    });
+  });
+
+  it("toggles sub-agent session visibility in sidebar", async () => {
+    const onUpdateAppSettings = vi.fn().mockResolvedValue(undefined);
+    renderDisplaySection({
+      onUpdateAppSettings,
+      appSettings: { showSubagentSessions: false },
+    });
+
+    const row = screen
+      .getByText("Show sub-agent sessions in sidebar")
+      .closest(".settings-toggle-row") as HTMLElement | null;
+    if (!row) {
+      throw new Error("Expected sub-agent session visibility row");
+    }
+    fireEvent.click(within(row).getByRole("button"));
+
+    await waitFor(() => {
+      expect(onUpdateAppSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ showSubagentSessions: true }),
+      );
+    });
+  });
+
+  it("updates settings sync mode", async () => {
+    const onUpdateAppSettings = vi.fn().mockResolvedValue(undefined);
+    renderDisplaySection({
+      onUpdateAppSettings,
+      appSettings: { syncMode: "app_authoritative" },
+    });
+
+    const select = screen.getByLabelText("Settings sync mode");
+    fireEvent.change(select, { target: { value: "bidirectional" } });
+
+    await waitFor(() => {
+      expect(onUpdateAppSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ syncMode: "bidirectional" }),
       );
     });
   });

--- a/src/features/settings/components/sections/SettingsDisplaySection.tsx
+++ b/src/features/settings/components/sections/SettingsDisplaySection.tsx
@@ -592,6 +592,50 @@ export function SettingsDisplaySection({
           <span className="settings-toggle-knob" />
         </button>
       </div>
+      <div className="settings-toggle-row">
+        <div>
+          <div className="settings-toggle-title">Show sub-agent sessions in sidebar</div>
+          <div className="settings-toggle-subtitle">
+            Show or hide spawned sub-agent sessions beneath their parent thread.
+          </div>
+        </div>
+        <button
+          type="button"
+          className={`settings-toggle ${appSettings.showSubagentSessions ? "on" : ""}`}
+          onClick={() =>
+            void onUpdateAppSettings({
+              ...appSettings,
+              showSubagentSessions: !appSettings.showSubagentSessions,
+            })
+          }
+          aria-pressed={appSettings.showSubagentSessions}
+        >
+          <span className="settings-toggle-knob" />
+        </button>
+      </div>
+      <div className="settings-field">
+        <label className="settings-field-label" htmlFor="settings-sync-mode-select">
+          Settings sync mode
+        </label>
+        <select
+          id="settings-sync-mode-select"
+          className="settings-select"
+          value={appSettings.syncMode}
+          onChange={(event) =>
+            void onUpdateAppSettings({
+              ...appSettings,
+              syncMode: event.target.value as AppSettings["syncMode"],
+            })
+          }
+        >
+          <option value="app_authoritative">App authoritative</option>
+          <option value="bidirectional">Bidirectional</option>
+        </select>
+        <div className="settings-help">
+          App authoritative keeps CodexMonitor as the source of truth. Bidirectional preserves
+          direct file edits when possible and syncs changes both ways.
+        </div>
+      </div>
       <div className="settings-sound-actions">
         <button
           type="button"

--- a/src/features/settings/hooks/useAppSettings.test.ts
+++ b/src/features/settings/hooks/useAppSettings.test.ts
@@ -53,6 +53,7 @@ describe("useAppSettings", () => {
     expect(result.current.settings.codeFontFamily).toContain("ui-monospace");
     expect(result.current.settings.codeFontSize).toBe(16);
     expect(result.current.settings.personality).toBe("friendly");
+    expect(result.current.settings.syncMode).toBe("app_authoritative");
     expect(result.current.settings.backendMode).toBe("remote");
     expect(result.current.settings.remoteBackendHost).toBe("example:1234");
   });
@@ -69,6 +70,7 @@ describe("useAppSettings", () => {
     expect(result.current.settings.uiFontFamily).toContain("system-ui");
     expect(result.current.settings.codeFontFamily).toContain("ui-monospace");
     expect(result.current.settings.backendMode).toBe("local");
+    expect(result.current.settings.showSubagentSessions).toBe(true);
     expect(result.current.settings.dictationModelId).toBe("base");
     expect(result.current.settings.interruptShortcut).toBeTruthy();
   });

--- a/src/features/settings/hooks/useAppSettings.ts
+++ b/src/features/settings/hooks/useAppSettings.ts
@@ -23,6 +23,7 @@ import { DEFAULT_COMMIT_MESSAGE_PROMPT } from "@utils/commitMessagePrompt";
 const allowedThemes = new Set(["system", "light", "dark", "dim"]);
 const allowedPersonality = new Set(["friendly", "pragmatic"]);
 const allowedFollowUpMessageBehavior = new Set(["queue", "steer"]);
+const allowedSyncModes = new Set(["app_authoritative", "bidirectional"]);
 const DEFAULT_REMOTE_BACKEND_HOST = "127.0.0.1:4732";
 const DEFAULT_REMOTE_BACKEND_ID = "remote-default";
 const DEFAULT_REMOTE_BACKEND_NAME = "Primary remote";
@@ -177,6 +178,8 @@ function buildDefaultSettings(): AppSettings {
     notificationSoundsEnabled: true,
     systemNotificationsEnabled: true,
     subagentSystemNotificationsEnabled: true,
+    showSubagentSessions: true,
+    syncMode: "app_authoritative",
     splitChatDiffView: false,
     preloadGitDiffs: true,
     gitDiffIgnoreWhitespaceChanges: false,
@@ -264,6 +267,9 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
       : settings.steerEnabled
         ? "steer"
         : "queue",
+    syncMode: allowedSyncModes.has(settings.syncMode)
+      ? settings.syncMode
+      : "app_authoritative",
     composerFollowUpHintEnabled:
       typeof settings.composerFollowUpHintEnabled === "boolean"
         ? settings.composerFollowUpHintEnabled

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -959,6 +959,38 @@
   position: relative;
 }
 
+.thread-collapse-toggle {
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  padding: 0;
+  width: 12px;
+  height: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.thread-collapse-toggle svg {
+  transition: transform 0.15s ease;
+}
+
+.thread-collapse-toggle.collapsed svg {
+  transform: rotate(0deg);
+}
+
+.thread-collapse-toggle:not(.collapsed) svg {
+  transform: rotate(90deg);
+}
+
+.thread-collapse-toggle:hover {
+  color: var(--text-strong);
+  background: var(--surface-hover);
+}
+
 .thread-status {
   width: 6px;
   height: 6px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,7 @@ export type RemoteBackendTarget = {
 };
 export type ThemePreference = "system" | "light" | "dark" | "dim";
 export type PersonalityPreference = "friendly" | "pragmatic";
+export type SettingsSyncMode = "app_authoritative" | "bidirectional";
 export type FollowUpMessageBehavior = "queue" | "steer";
 export type ComposerSendIntent = "default" | "queue" | "steer";
 export type SendMessageResult = {
@@ -245,6 +246,8 @@ export type AppSettings = {
   notificationSoundsEnabled: boolean;
   systemNotificationsEnabled: boolean;
   subagentSystemNotificationsEnabled: boolean;
+  showSubagentSessions: boolean;
+  syncMode: SettingsSyncMode;
   splitChatDiffView: boolean;
   preloadGitDiffs: boolean;
   gitDiffIgnoreWhitespaceChanges: boolean;


### PR DESCRIPTION
## Summary
- add settings sync mode (app_authoritative default, bidirectional optional)
- keep app-authoritative behavior by default while supporting bidirectional reconciliation in settings core
- add sidebar controls for subagent session visibility and per-parent collapse/expand
- wire new settings through frontend + backend models and UI

## Testing
- npm run typecheck
- npm run test
- cd src-tauri && cargo check

## Notes
- commit: 22aaebc
- preserves existing behavior unless sync mode is explicitly switched to bidirectional