### PR TITLE
fix: Textarea CSS improvements for code blocks

### DIFF
--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -1052,8 +1052,10 @@
   border-radius: 10px;
   background: var(--surface-command);
   overflow: hidden;
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.14);
-  margin: 6px 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  margin: 8px 0;
+  width: 100%;
+  max-width: 100%;
 }
 
 .message .markdown-codeblock-header {
@@ -1097,6 +1099,9 @@
   padding: 10px 12px 12px;
   white-space: pre;
   overflow-x: auto;
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
   font-family: var(--code-font-family);
   font-size: var(--code-font-size, 11px);
   font-weight: var(--code-font-weight, 400);
@@ -1104,18 +1109,21 @@
 }
 
 .message .markdown-codeblock-single {
-  margin: 6px 0;
+  margin: 8px 0;
   padding: 10px 12px 12px;
   border: 1px solid var(--border-stronger);
   border-radius: 10px;
   background: var(--surface-command);
   white-space: pre;
   overflow-x: auto;
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
   font-family: var(--code-font-family);
   font-size: var(--code-font-size, 11px);
   font-weight: var(--code-font-weight, 400);
   line-height: var(--code-line-height, 1.28);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.14);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
 .message .markdown-codeblock-single code {
@@ -1173,7 +1181,7 @@
   margin: 0;
 }
 
-.message.assistant .markdown :where(p, ul, ol, pre, blockquote) {
+.message.assistant .markdown :where(p, ul, ol, blockquote) {
   max-width: 94ch;
 }
 


### PR DESCRIPTION
**Synopsis.**
On larger screens (1920px), when getting lines of text with codeblock/textareas, the textareas text was being cut off at a certain point and made it hard to see full paths. Also, if a codeblock / textarea was on top of other text, it was cutting off the text below it a little bit. Screenshots attached of the issue and the improvements.

**Screenshots.**
Issue ::
<img width="1466" height="436" alt="CleanShot 2026-03-10 at 21 46 28" src="https://github.com/user-attachments/assets/4948243a-d513-4422-b30f-3e370b06b553" />

Improvements ::
<img width="1477" height="400" alt="CleanShot 2026-03-10 at 21 57 39" src="https://github.com/user-attachments/assets/99de0d1d-ac5e-4479-afa7-1de64ac25fa0" />

