### PR TITLE
fix: allow daemon binaries to build on Linux without GTK4/WebKit

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,21 @@ default-run = "codex-monitor"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-custom-protocol = ["tauri/custom-protocol"]
+default = ["tauri-app"]
+tauri-app = [
+  "dep:tauri-build",
+  "dep:tauri",
+  "dep:tauri-plugin-liquid-glass",
+  "dep:tauri-plugin-notification",
+  "dep:tauri-plugin-opener",
+  "dep:tauri-plugin-process",
+  "dep:tauri-plugin-dialog",
+  "dep:tauri-plugin-updater",
+  "dep:tauri-plugin-window-state",
+  "dep:cpal",
+  "dep:whisper-rs",
+]
+custom-protocol = ["tauri-app", "tauri/custom-protocol"]
 
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary
@@ -19,21 +33,21 @@ name = "codex_monitor_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.5.6", features = [] }
+tauri-build = { version = "2.5.6", features = [], optional = true }
 
 [dependencies]
-tauri = { version = "2.10.3", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-png"] }
-tauri-plugin-liquid-glass = "0.1"
-tauri-plugin-notification = "2"
-tauri-plugin-opener = "2"
-tauri-plugin-process = "2"
+tauri = { version = "2.10.3", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-png"], optional = true }
+tauri-plugin-liquid-glass = { version = "0.1", optional = true }
+tauri-plugin-notification = { version = "2", optional = true }
+tauri-plugin-opener = { version = "2", optional = true }
+tauri-plugin-process = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "net", "io-util", "process", "rt", "sync", "time"] }
 futures-util = "0.3"
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 uuid = { version = "1", features = ["v4"] }
-tauri-plugin-dialog = "2"
+tauri-plugin-dialog = { version = "2", optional = true }
 git2 = { version = "0.20.3", features = ["vendored-openssl", "vendored-libgit2"] }
 base64 = "0.22"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
@@ -45,10 +59,10 @@ shell-words = "1.1"
 toml_edit = "0.20.2"
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
-tauri-plugin-updater = "2.10.0"
-tauri-plugin-window-state = "2"
-cpal = "0.15"
-whisper-rs = "0.12"
+tauri-plugin-updater = { version = "2.10.0", optional = true }
+tauri-plugin-window-state = { version = "2", optional = true }
+cpal = { version = "0.15", optional = true }
+whisper-rs = { version = "0.12", optional = true }
 sha2 = "0.10"
 portable-pty = "0.8"
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    #[cfg(feature = "tauri-app")]
     tauri_build::build();
 
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("ios") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "tauri-app")]
+
 #[cfg(desktop)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;


### PR DESCRIPTION
## Problem

On Linux distributions based on RHEL 8 (CentOS Stream 8, Rocky Linux 8, etc.), `webkit2gtk4.1` and `libsoup-3.0` are **not available** in the standard package repositories.

This makes it impossible to compile `codex_monitor_daemon` and `codex_monitor_daemonctl` on these platforms, even though the daemon binaries themselves do not use Tauri or WebKit at all.

```
error: failed to run custom build command for `soup3-sys`
  The system library `libsoup-3.0` required by crate `soup3-sys` was not found.

error: failed to run custom build command for `javascriptcore-rs-sys`
  The system library `javascriptcoregtk-4.1` required by crate `javascriptcore-rs-sys` was not found.
```

**Root cause:** `tauri` is an unconditional `[dependency]` and `build.rs` calls `tauri_build::build()` unconditionally, so every compilation target in the package — including the daemons — triggers the GTK4/WebKit dependency chain.

## Fix

Introduce a `tauri-app` Cargo feature (enabled by default) that gates all GTK4/WebKit-requiring dependencies. Three minimal changes:

**`Cargo.toml`** — introduce feature, mark heavy deps as `optional`:
```toml
[features]
default = ["tauri-app"]
tauri-app = ["dep:tauri-build", "dep:tauri", "dep:tauri-plugin-liquid-glass", ...]
```

**`build.rs`** — gate the Tauri build hook:
```rust
#[cfg(feature = "tauri-app")]
tauri_build::build();
```

**`src/lib.rs`** — gate the entire lib (which uses Tauri APIs):
```rust
#![cfg(feature = "tauri-app")]
```

## Result

Daemon-only build on systems without GTK4 (RHEL 8 based distros, etc.):
```bash
cargo build --release --no-default-features   --bin codex_monitor_daemon   --bin codex_monitor_daemonctl
```

Default full app build — **completely unchanged**:
```bash
cargo build --release  # macOS / Ubuntu 22.04+ unaffected
```