### PR TITLE
fix: prevent ambiguous slash phrases from rendering as file links

### DIFF
--- a/src/features/messages/components/Markdown.test.tsx
+++ b/src/features/messages/components/Markdown.test.tsx
@@ -273,4 +273,43 @@ describe("Markdown file-like href behavior", () => {
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(onOpenFileLink).not.toHaveBeenCalled();
   });
+
+  it("does not turn natural-language slash phrases into file links", () => {
+    const { container } = render(
+      <Markdown
+        value="Keep the current app/daemon behavior and the existing Git/Plan experience."
+        className="markdown"
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.textContent).toContain("app/daemon");
+    expect(container.textContent).toContain("Git/Plan");
+  });
+
+  it("does not turn longer slash phrases into file links", () => {
+    const { container } = render(
+      <Markdown
+        value="This keeps Spec/Verification/Evidence in the note without turning it into a file link."
+        className="markdown"
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.textContent).toContain("Spec/Verification/Evidence");
+  });
+
+  it("still turns clear file paths in plain text into file links", () => {
+    const { container } = render(
+      <Markdown
+        value="See docs/setup.md and /Users/example/project/src/index.ts for details."
+        className="markdown"
+      />,
+    );
+
+    const fileLinks = [...container.querySelectorAll(".message-file-link")];
+    expect(fileLinks).toHaveLength(2);
+    expect(fileLinks[0]?.textContent).toContain("setup.md");
+    expect(fileLinks[1]?.textContent).toContain("index.ts");
+  });
 });

--- a/src/utils/remarkFileLinks.ts
+++ b/src/utils/remarkFileLinks.ts
@@ -9,17 +9,7 @@ const FILE_PATH_PATTERN =
 const FILE_PATH_MATCH = new RegExp(`^${FILE_PATH_PATTERN.source}$`);
 
 const TRAILING_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?", ")", "]", "}"]);
-const RELATIVE_ALLOWED_PREFIXES = [
-  "src/",
-  "app/",
-  "lib/",
-  "tests/",
-  "test/",
-  "packages/",
-  "apps/",
-  "docs/",
-  "scripts/",
-];
+const LETTER_OR_NUMBER_PATTERN = /[\p{L}\p{N}.]/u;
 
 type MarkdownNode = {
   type: string;
@@ -43,7 +33,11 @@ function isPathCandidate(
     return false;
   }
   if (value.startsWith("/") || value.startsWith("./") || value.startsWith("../")) {
-    if (value.startsWith("/") && previousChar && /[A-Za-z0-9.]/.test(previousChar)) {
+    if (
+      value.startsWith("/") &&
+      previousChar &&
+      LETTER_OR_NUMBER_PATTERN.test(previousChar)
+    ) {
       return false;
     }
     return true;
@@ -52,10 +46,7 @@ function isPathCandidate(
     return true;
   }
   const lastSegment = value.split("/").pop() ?? "";
-  if (lastSegment.includes(".")) {
-    return true;
-  }
-  return RELATIVE_ALLOWED_PREFIXES.some((prefix) => value.startsWith(prefix));
+  return lastSegment.includes(".");
 }
 
 function splitTrailingPunctuation(value: string) {


### PR DESCRIPTION
## Synopsis

CodexMonitor was incorrectly turning natural-language slash phrases like `app/daemon`,
`Git/Plan`, and `Spec/Verification/Evidence` into file links in rendered messages.

The raw `agentMessage.text` from `thread/resume response` was correct, so the issue was in
frontend markdown rendering, specifically the plain-text file linkification logic in
`remarkFileLinks`.

## Before
- natural-language slash phrases were rendered as file links
<img width="957" height="123" alt="image" src="https://github.com/user-attachments/assets/1588bfd0-0414-4ecb-a9a5-e97bc8fc9ba5" />


## After
<img width="955" height="191" alt="image" src="https://github.com/user-attachments/assets/6825dca9-4610-4fd0-974c-6b516592e30b" />


## Changes

- make plain-text file linkification more conservative
- stop treating ambiguous slash phrases as file paths
- keep explicit file-like paths such as `docs/setup.md` linkable
- add regression tests for markdown rendering behavior

## Validation

- `npm run test -- src/features/messages/components/Markdown.test.tsx`
- `npm run typecheck`
- manual verification in `npm run tauri:dev`