### PR TITLE
Tighten message file-path detection for non-English text

### DIFF
--- a/src/features/messages/components/Markdown.test.tsx
+++ b/src/features/messages/components/Markdown.test.tsx
@@ -27,6 +27,51 @@ describe("Markdown file-like href behavior", () => {
     expect(clickEvent.defaultPrevented).toBe(true);
   });
 
+  it("does not auto-link slash-delimited non-Latin prose as a file path", () => {
+    const { container } = render(
+      <Markdown
+        value={'测试文本"甲/乙"测试文本'}
+        className="markdown"
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector('a[href^="codex-file:"]')).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      '测试文本"甲/乙"测试文本',
+    );
+  });
+
+  it("does not auto-link slash-delimited Japanese prose as a file path", () => {
+    const { container } = render(
+      <Markdown
+        value="テスト本文「甲/乙」テスト本文"
+        className="markdown"
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector('a[href^="codex-file:"]')).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      "テスト本文「甲/乙」テスト本文",
+    );
+  });
+
+  it("does not auto-link bare file-like prose outside code or markdown links", () => {
+    const { container } = render(
+      <Markdown
+        value="See src/features/messages/components/Markdown.tsx:244 for details"
+        className="markdown"
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector('a[href^="codex-file:"]')).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      "See src/features/messages/components/Markdown.tsx:244 for details",
+    );
+  });
+
   it("intercepts file-like href clicks when a file opener is provided", () => {
     const onOpenFileLink = vi.fn();
     render(
@@ -90,6 +135,73 @@ describe("Markdown file-like href behavior", () => {
     fireEvent(link as Element, clickEvent);
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(onOpenFileLink).toHaveBeenCalledWith("/workspace/src/example.ts");
+  });
+
+  it("intercepts Windows drive hrefs when a file opener is provided", () => {
+    const onOpenFileLink = vi.fn();
+    render(
+      <Markdown
+        value={"See [app](D:\\repo\\src\\App.tsx:12)"}
+        className="markdown"
+        onOpenFileLink={onOpenFileLink}
+      />,
+    );
+
+    const link = screen.getByText("app").closest("a");
+    expect(link?.getAttribute("href")).toContain("D:");
+    expect(link?.getAttribute("href")).toContain("%5C");
+
+    const clickEvent = createEvent.click(link as Element, {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(link as Element, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(onOpenFileLink).toHaveBeenCalledWith("D:\\repo\\src\\App.tsx:12");
+  });
+
+  it("intercepts git-bash style drive hrefs when a file opener is provided", () => {
+    const onOpenFileLink = vi.fn();
+    render(
+      <Markdown
+        value="See [workspace](/c/projects/CodexMonitor/src/App.tsx)"
+        className="markdown"
+        onOpenFileLink={onOpenFileLink}
+      />,
+    );
+
+    const link = screen.getByText("workspace").closest("a");
+    expect(link?.getAttribute("href")).toBe("/c/projects/CodexMonitor/src/App.tsx");
+
+    const clickEvent = createEvent.click(link as Element, {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(link as Element, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(onOpenFileLink).toHaveBeenCalledWith("/c/projects/CodexMonitor/src/App.tsx");
+  });
+
+  it("intercepts encoded UNC hrefs when a file opener is provided", () => {
+    const onOpenFileLink = vi.fn();
+    render(
+      <Markdown
+        value="See [share](%5C%5Cserver%5Cshare%5Cfile.txt)"
+        className="markdown"
+        onOpenFileLink={onOpenFileLink}
+      />,
+    );
+
+    const link = screen.getByText("share").closest("a");
+    expect(link?.getAttribute("href")).toBe("%5C%5Cserver%5Cshare%5Cfile.txt");
+
+    const clickEvent = createEvent.click(link as Element, {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(link as Element, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(onOpenFileLink).toHaveBeenCalledWith("\\\\server\\share\\file.txt");
   });
 
   it("still intercepts dotless workspace file hrefs when a file opener is provided", () => {

--- a/src/features/messages/components/Markdown.tsx
+++ b/src/features/messages/components/Markdown.tsx
@@ -6,7 +6,6 @@ import {
   decodeFileLink,
   isFileLinkUrl,
   isLinkableFilePath,
-  remarkFileLinks,
   toFileLink,
 } from "../../../utils/remarkFileLinks";
 import { resolveMountedWorkspacePath } from "../utils/mountedWorkspacePaths";
@@ -358,7 +357,11 @@ function isLikelyFileHref(
   if (/[?#]/.test(trimmed)) {
     return false;
   }
-  if (/^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.startsWith("\\\\")) {
+  if (
+    /^[A-Za-z]:[\\/]/.test(trimmed) ||
+    trimmed.startsWith("\\\\") ||
+    /^\/[A-Za-z](?:\/|$)/.test(trimmed)
+  ) {
     return true;
   }
   if (trimmed.startsWith("/")) {
@@ -882,11 +885,12 @@ export function Markdown({
   return (
     <div className={className}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkFileLinks]}
+        remarkPlugins={[remarkGfm]}
         urlTransform={(url) => {
           const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url);
           if (
             isFileLinkUrl(url) ||
+            resolveHrefFilePath(url) ||
             url.startsWith("http://") ||
             url.startsWith("https://") ||
             url.startsWith("mailto:") ||

--- a/src/features/messages/components/Messages.test.tsx
+++ b/src/features/messages/components/Messages.test.tsx
@@ -276,6 +276,324 @@ describe("Messages", () => {
     );
   });
 
+  it("does not auto-link bare file paths in normal message text", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-bare-file-text",
+        kind: "message",
+        role: "assistant",
+        text: "See src/features/messages/components/Markdown.tsx:244 for details.",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      "See src/features/messages/components/Markdown.tsx:244 for details.",
+    );
+    expect(openFileLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps slash-delimited non-Latin prose as normal message text", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-chinese-slash-text",
+        kind: "message",
+        role: "assistant",
+        text: 'Session 测试文本"甲/乙"测试文本',
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      'Session 测试文本"甲/乙"测试文本',
+    );
+    expect(openFileLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps slash-delimited Japanese prose as normal message text", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-japanese-slash-text",
+        kind: "message",
+        role: "assistant",
+        text: "Session テスト本文「甲/乙」テスト本文",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      "Session テスト本文「甲/乙」テスト本文",
+    );
+    expect(openFileLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps slash-delimited non-file inline code as plain code text", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-chinese-slash-inline-code",
+        kind: "message",
+        role: "assistant",
+        text: '说明：`甲/乙` 摘要',
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    const inlineCode = container.querySelector(".markdown code");
+    expect(inlineCode?.textContent).toBe("甲/乙");
+    expect(openFileLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("renders Windows drive inline code paths as compact links and opens them", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-windows-inline-code",
+        kind: "message",
+        role: "assistant",
+        text: "Open `D:\\repo\\src\\App.tsx:12` next.",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(screen.getByText("App.tsx")).toBeTruthy();
+    expect(screen.getByText("L12")).toBeTruthy();
+    expect(screen.getByText("D:/repo/src")).toBeTruthy();
+
+    const fileLink = container.querySelector(".message-file-link");
+    expect(fileLink).toBeTruthy();
+    fireEvent.click(fileLink as Element);
+    expect(openFileLinkMock).toHaveBeenCalledWith("D:\\repo\\src\\App.tsx:12");
+  });
+
+  it("renders Windows drive roots inside inline code as compact links and opens them", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-windows-drive-root-inline-code",
+        kind: "message",
+        role: "assistant",
+        text: "Open `D:\\` next.",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    const fileLink = container.querySelector(".message-file-link");
+    expect(fileLink).toBeTruthy();
+    expect(screen.getByText("D:")).toBeTruthy();
+
+    fireEvent.click(fileLink as Element);
+    expect(openFileLinkMock).toHaveBeenCalledWith("D:\\");
+  });
+
+  it("renders /c/ style inline code paths as compact links and opens them", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-cygwin-inline-code",
+        kind: "message",
+        role: "assistant",
+        text: "Open `/c/abc/def.ts` next.",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(screen.getByText("def.ts")).toBeTruthy();
+    expect(screen.getByText("/c/abc")).toBeTruthy();
+
+    const fileLink = container.querySelector(".message-file-link");
+    expect(fileLink).toBeTruthy();
+    fireEvent.click(fileLink as Element);
+    expect(openFileLinkMock).toHaveBeenCalledWith("/c/abc/def.ts");
+  });
+
+  it("renders UNC inline code paths as compact links and opens them", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-unc-inline-code",
+        kind: "message",
+        role: "assistant",
+        text: "Open `\\\\server\\share\\file.txt` next.",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(screen.getByText("file.txt")).toBeTruthy();
+    expect(screen.getByText("//server/share")).toBeTruthy();
+
+    const fileLink = container.querySelector(".message-file-link");
+    expect(fileLink).toBeTruthy();
+    fireEvent.click(fileLink as Element);
+    expect(openFileLinkMock).toHaveBeenCalledWith("\\\\server\\share\\file.txt");
+  });
+
+  it("keeps bare file-like prose as normal message text", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-bare-file-like-prose",
+        kind: "message",
+        role: "assistant",
+        text: "See src/features/messages/components/Markdown.tsx:244 for details",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    expect(container.querySelector(".message-file-link")).toBeNull();
+    expect(container.querySelector(".markdown")?.textContent ?? "").toContain(
+      "See src/features/messages/components/Markdown.tsx:244 for details",
+    );
+    expect(openFileLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("renders Windows drive file references as compact links and opens them", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-windows-drive-file-link",
+        kind: "message",
+        role: "assistant",
+        text: "Reference: `D:\\repo\\src\\App.tsx:42`",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    const fileLink = container.querySelector(".message-file-link");
+    expect(fileLink).toBeTruthy();
+    expect(screen.getByText("App.tsx")).toBeTruthy();
+    expect(screen.getByText("L42")).toBeTruthy();
+
+    fireEvent.click(fileLink as Element);
+    expect(openFileLinkMock).toHaveBeenCalledWith("D:\\repo\\src\\App.tsx:42");
+  });
+
+  it("renders git-bash style drive file references as compact links and opens them", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg-git-bash-drive-file-link",
+        kind: "message",
+        role: "assistant",
+        text: "Reference: `/c/projects/CodexMonitor/src/App.tsx`",
+      },
+    ];
+
+    const { container } = render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    const fileLink = container.querySelector(".message-file-link");
+    expect(fileLink).toBeTruthy();
+    expect(screen.getByText("App.tsx")).toBeTruthy();
+
+    fireEvent.click(fileLink as Element);
+    expect(openFileLinkMock).toHaveBeenCalledWith("/c/projects/CodexMonitor/src/App.tsx");
+  });
+
   it("routes markdown href file paths through the file opener", () => {
     const linkedPath =
       "/Users/dimillian/Documents/Dev/CodexMonitor/src/features/messages/components/Markdown.tsx:244";
@@ -326,6 +644,58 @@ describe("Messages", () => {
     );
 
     fireEvent.click(screen.getByText("app file"));
+    expect(openFileLinkMock).toHaveBeenCalledWith(linkedPath);
+  });
+
+  it("routes Windows drive href file paths through the file opener", () => {
+    const linkedPath = "D:\\repo\\src\\App.tsx:12";
+    const items: ConversationItem[] = [
+      {
+        id: "msg-file-href-windows-drive-link",
+        kind: "message",
+        role: "assistant",
+        text: `Open [app](${linkedPath})`,
+      },
+    ];
+
+    render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    fireEvent.click(screen.getByText("app"));
+    expect(openFileLinkMock).toHaveBeenCalledWith(linkedPath);
+  });
+
+  it("routes git-bash style drive href file paths through the file opener", () => {
+    const linkedPath = "/c/projects/CodexMonitor/src/App.tsx";
+    const items: ConversationItem[] = [
+      {
+        id: "msg-file-href-git-bash-drive-link",
+        kind: "message",
+        role: "assistant",
+        text: `Open [app](${linkedPath})`,
+      },
+    ];
+
+    render(
+      <Messages
+        items={items}
+        threadId="thread-1"
+        workspaceId="ws-1"
+        isThinking={false}
+        openTargets={[]}
+        selectedOpenAppId=""
+      />,
+    );
+
+    fireEvent.click(screen.getByText("app"));
     expect(openFileLinkMock).toHaveBeenCalledWith(linkedPath);
   });
 

--- a/src/utils/remarkFileLinks.ts
+++ b/src/utils/remarkFileLinks.ts
@@ -1,149 +1,19 @@
 const FILE_LINK_PROTOCOL = "codex-file:";
-const FILE_LINE_SUFFIX_PATTERN = "(?::\\d+(?::\\d+)?)?";
 
-const FILE_PATH_PATTERN =
-  new RegExp(
-    `(\\/[^\\s\\\`"'<>]+|~\\/[^\\s\\\`"'<>]+|\\.{1,2}\\/[^\\s\\\`"'<>]+|[A-Za-z0-9._-]+(?:\\/[A-Za-z0-9._-]+)+)${FILE_LINE_SUFFIX_PATTERN}`,
-    "g",
-  );
-const FILE_PATH_MATCH = new RegExp(`^${FILE_PATH_PATTERN.source}$`);
-
-const TRAILING_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?", ")", "]", "}"]);
-const RELATIVE_ALLOWED_PREFIXES = [
-  "src/",
-  "app/",
-  "lib/",
-  "tests/",
-  "test/",
-  "packages/",
-  "apps/",
-  "docs/",
-  "scripts/",
-];
-
-type MarkdownNode = {
-  type: string;
-  value?: string;
-  url?: string;
-  children?: MarkdownNode[];
-};
-
-function isPathCandidate(
-  value: string,
-  leadingContext: string,
-  previousChar: string,
-) {
-  if (!value.includes("/")) {
-    return false;
-  }
-  if (value.startsWith("//")) {
-    return false;
-  }
-  if (leadingContext.endsWith("://")) {
-    return false;
-  }
-  if (value.startsWith("/") || value.startsWith("./") || value.startsWith("../")) {
-    if (value.startsWith("/") && previousChar && /[A-Za-z0-9.]/.test(previousChar)) {
-      return false;
-    }
-    return true;
-  }
-  if (value.startsWith("~/")) {
-    return true;
-  }
-  const lastSegment = value.split("/").pop() ?? "";
-  if (lastSegment.includes(".")) {
-    return true;
-  }
-  return RELATIVE_ALLOWED_PREFIXES.some((prefix) => value.startsWith(prefix));
-}
-
-function splitTrailingPunctuation(value: string) {
-  let end = value.length;
-  while (end > 0 && TRAILING_PUNCTUATION.has(value[end - 1])) {
-    end -= 1;
-  }
-  return {
-    path: value.slice(0, end),
-    trailing: value.slice(end),
-  };
-}
+const POSIX_ABSOLUTE_PATH_PATTERN = /^\/[^\s`"'<>]+(?:\/[^\s`"'<>]+)*\/?$/;
+const HOME_PATH_PATTERN = /^~\/[^\s`"'<>]+(?:\/[^\s`"'<>]+)*\/?$/;
+const DOT_RELATIVE_PATH_PATTERN = /^\.{1,2}\/[^\s`"'<>]+(?:\/[^\s`"'<>]+)*\/?$/;
+const FORWARD_SLASH_RELATIVE_PATH_PATTERN =
+  /^(?:[A-Za-z0-9._-]+\/){1,}[A-Za-z0-9._-]+\/?$/;
+const WINDOWS_DRIVE_PATH_PATTERN =
+  /^[A-Za-z]:[\\/](?:[^\s`"'<>]+(?:[\\/][^\s`"'<>]+)*)?[\\/]?$/;
+const WINDOWS_UNC_PATH_PATTERN =
+  /^\\\\[^\s\\/`"'<>]+\\[^\s\\/`"'<>]+(?:\\[^\s\\/`"'<>]+)*\\?$/;
+const BACKSLASH_RELATIVE_PATH_PATTERN =
+  /^(?:[A-Za-z0-9._-]+\\){1,}[A-Za-z0-9._-]+\\?$/;
 
 export function toFileLink(path: string) {
   return `${FILE_LINK_PROTOCOL}${encodeURIComponent(path)}`;
-}
-
-function linkifyText(value: string) {
-  FILE_PATH_PATTERN.lastIndex = 0;
-  const nodes: MarkdownNode[] = [];
-  let lastIndex = 0;
-  let hasLink = false;
-
-  for (const match of value.matchAll(FILE_PATH_PATTERN)) {
-    const matchIndex = match.index ?? 0;
-    const raw = match[0];
-    if (matchIndex > lastIndex) {
-      nodes.push({ type: "text", value: value.slice(lastIndex, matchIndex) });
-    }
-
-    const leadingContext = value.slice(Math.max(0, matchIndex - 3), matchIndex);
-    const previousChar = matchIndex > 0 ? value[matchIndex - 1] : "";
-    const { path, trailing } = splitTrailingPunctuation(raw);
-    if (path && isPathCandidate(path, leadingContext, previousChar)) {
-      nodes.push({
-        type: "link",
-        url: toFileLink(path),
-        children: [{ type: "text", value: path }],
-      });
-      if (trailing) {
-        nodes.push({ type: "text", value: trailing });
-      }
-      hasLink = true;
-    } else {
-      nodes.push({ type: "text", value: raw });
-    }
-
-    lastIndex = matchIndex + raw.length;
-  }
-
-  if (lastIndex < value.length) {
-    nodes.push({ type: "text", value: value.slice(lastIndex) });
-  }
-
-  return hasLink ? nodes : null;
-}
-
-function isSkippableParent(parentType?: string) {
-  return parentType === "link" || parentType === "inlineCode" || parentType === "code";
-}
-
-function walk(node: MarkdownNode, parentType?: string) {
-  if (!node.children) {
-    return;
-  }
-
-  for (let index = 0; index < node.children.length; index += 1) {
-    const child = node.children[index];
-    if (
-      child.type === "text" &&
-      typeof child.value === "string" &&
-      !isSkippableParent(parentType)
-    ) {
-      const nextNodes = linkifyText(child.value);
-      if (nextNodes) {
-        node.children.splice(index, 1, ...nextNodes);
-        index += nextNodes.length - 1;
-        continue;
-      }
-    }
-    walk(child, child.type);
-  }
-}
-
-export function remarkFileLinks() {
-  return (tree: MarkdownNode) => {
-    walk(tree);
-  };
 }
 
 export function isLinkableFilePath(value: string) {
@@ -151,10 +21,15 @@ export function isLinkableFilePath(value: string) {
   if (!trimmed) {
     return false;
   }
-  if (!FILE_PATH_MATCH.test(trimmed)) {
-    return false;
-  }
-  return isPathCandidate(trimmed, "", "");
+  return (
+    POSIX_ABSOLUTE_PATH_PATTERN.test(trimmed) ||
+    HOME_PATH_PATTERN.test(trimmed) ||
+    DOT_RELATIVE_PATH_PATTERN.test(trimmed) ||
+    FORWARD_SLASH_RELATIVE_PATH_PATTERN.test(trimmed) ||
+    WINDOWS_DRIVE_PATH_PATTERN.test(trimmed) ||
+    WINDOWS_UNC_PATH_PATTERN.test(trimmed) ||
+    BACKSLASH_RELATIVE_PATH_PATTERN.test(trimmed)
+  );
 }
 
 export function isFileLinkUrl(url: string) {


### PR DESCRIPTION
```md
## Summary
The current message renderer too aggressively auto-detects file paths in plain text. In non-English content, slash-delimited prose such as Chinese or Japanese text is frequently misclassified as a clickable file chip, which noticeably disrupts normal reading and copying.

This change narrows file-path detection to explicit cases only:
- markdown links
- inline code

It also preserves support for Windows-style explicit paths such as `D:\...`, `D:\`, and `/c/...`.

## Why
- The current heuristic fires too often in non-English text and causes high-frequency false positives.
- These false positives are disruptive enough to affect normal message use.
- Restricting detection to explicit path formatting is simpler and more predictable than expanding plain-text heuristics.

## Validation
- npm run test -- src/features/messages/components/Markdown.test.tsx src/features/messages/components/Messages.test.tsx
- npm run typecheck
```