### PR TITLE
fix: use runtime version in settings

### DIFF
--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { getVersion } from "@tauri-apps/api/app";
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { AppSettings, WorkspaceInfo } from "@/types";
@@ -29,6 +30,10 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn(),
+}));
+
 vi.mock("@services/tauri", async () => {
   const actual = await vi.importActual<typeof import("@services/tauri")>(
     "@services/tauri",
@@ -47,6 +52,7 @@ vi.mock("@services/tauri", async () => {
 });
 
 const connectWorkspaceMock = vi.mocked(connectWorkspace);
+const getVersionMock = vi.mocked(getVersion);
 const getAppBuildTypeMock = vi.mocked(getAppBuildType);
 const getConfigModelMock = vi.mocked(getConfigModel);
 const getModelListMock = vi.mocked(getModelList);
@@ -55,6 +61,7 @@ const getAgentsSettingsMock = vi.mocked(getAgentsSettings);
 const isMobileRuntimeMock = vi.mocked(isMobileRuntime);
 const listWorkspacesMock = vi.mocked(listWorkspaces);
 connectWorkspaceMock.mockResolvedValue(undefined);
+getVersionMock.mockResolvedValue("0.7.63");
 getAppBuildTypeMock.mockResolvedValue("release");
 getConfigModelMock.mockResolvedValue(null);
 isMobileRuntimeMock.mockResolvedValue(false);
@@ -750,6 +757,16 @@ describe("SettingsView About", () => {
 
     await waitFor(() => {
       expect(onToggleAutomaticAppUpdateChecks).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("prefers the runtime app version when available", async () => {
+    getVersionMock.mockResolvedValueOnce("0.7.63-runtime");
+
+    renderAboutSection();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("0.7.63-runtime", { selector: "code" })).toHaveLength(2);
     });
   });
 });

--- a/src/features/settings/components/sections/SettingsAboutSection.tsx
+++ b/src/features/settings/components/sections/SettingsAboutSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import type { AppSettings } from "@/types";
 import {
   getAppBuildType,
@@ -35,12 +36,33 @@ export function SettingsAboutSection({
   appSettings,
   onToggleAutomaticAppUpdateChecks,
 }: SettingsAboutSectionProps) {
+  const [appVersion, setAppVersion] = useState(__APP_VERSION__);
   const [appBuildType, setAppBuildType] = useState<AppBuildType | "unknown">("unknown");
   const [updaterEnabled, setUpdaterEnabled] = useState(false);
   const { state: updaterState, checkForUpdates, startUpdate } = useUpdater({
     enabled: updaterEnabled,
     autoCheckOnMount: false,
   });
+
+  useEffect(() => {
+    let active = true;
+    const loadVersion = async () => {
+      try {
+        const value = await getVersion();
+        if (active && value.trim().length > 0) {
+          setAppVersion(value);
+        }
+      } catch {
+        if (active) {
+          setAppVersion(__APP_VERSION__);
+        }
+      }
+    };
+    void loadVersion();
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -93,7 +115,7 @@ export function SettingsAboutSection({
     <SettingsSection title="About" subtitle="App version, build metadata, and update controls.">
       <div className="settings-field">
         <div className="settings-help">
-          Version: <code>{__APP_VERSION__}</code>
+          Version: <code>{appVersion}</code>
         </div>
         <div className="settings-help">
           Build type: <code>{appBuildType}</code>
@@ -122,7 +144,7 @@ export function SettingsAboutSection({
           />
         </SettingsToggleRow>
         <div className="settings-help">
-          Currently running version <code>{__APP_VERSION__}</code>
+          Currently running version <code>{appVersion}</code>
         </div>
         {!updaterEnabled && (
           <div className="settings-help">


### PR DESCRIPTION
## Summary
- read the Settings About version from Tauri runtime metadata instead of the compile-time app constant
- keep the compile-time version as a fallback when runtime lookup is unavailable
- add coverage for preferring the runtime version in the settings view test

## Testing
- npm run test -- src/features/settings/components/SettingsView.test.tsx
- npm run typecheck
