### PR TITLE
fix(ci): refresh macOS daemon binaries before signing

### DIFF
--- a/scripts/macos-fix-openssl.sh
+++ b/scripts/macos-fix-openssl.sh
@@ -50,14 +50,10 @@ daemonctl_path="${app_path}/Contents/MacOS/codex_monitor_daemonctl"
 daemon_source="${DAEMON_BINARY_PATH:-src-tauri/target/release/codex_monitor_daemon}"
 daemonctl_source="${DAEMONCTL_BINARY_PATH:-src-tauri/target/release/codex_monitor_daemonctl}"
 
-copy_if_missing() {
+sync_embedded_binary() {
   local source_path="$1"
   local destination_path="$2"
   local label="$3"
-
-  if [[ -f "${destination_path}" ]]; then
-    return
-  fi
 
   if [[ -f "${source_path}" ]]; then
     cp -f "${source_path}" "${destination_path}"
@@ -68,8 +64,8 @@ copy_if_missing() {
   fi
 }
 
-copy_if_missing "${daemon_source}" "${daemon_path}" "daemon"
-copy_if_missing "${daemonctl_source}" "${daemonctl_path}" "daemonctl"
+sync_embedded_binary "${daemon_source}" "${daemon_path}" "daemon"
+sync_embedded_binary "${daemonctl_source}" "${daemonctl_path}" "daemonctl"
 
 if [[ ! -f "${libssl}" || ! -f "${libcrypto}" ]]; then
   echo "OpenSSL dylibs not found at ${openssl_prefix}/lib"


### PR DESCRIPTION
## Summary
- always copy freshly built macOS daemon binaries into the app bundle before re-signing
- avoid leaving stale unsigned nested binaries in the bundle when release artifacts are reused across builds

## Why
The latest failed release run died in  during  with an unsigned  nested inside the app bundle. The helper script only replaced daemon binaries when they were missing, which let an existing stale unsigned binary survive in the Intel bundle layout.

## Validation
- 
- inspected failed run  and traced the failure to CODESIGN_IDENTITY is required. Example:
  CODESIGN_IDENTITY='Developer ID Application: Your Name (TEAMID)' scripts/macos-fix-openssl.sh
