### PR TITLE
fix(threads): avoid quadratic overlap check during resume hydration

### DIFF
--- a/src/features/threads/utils/threadActionHelpers.ts
+++ b/src/features/threads/utils/threadActionHelpers.ts
@@ -162,10 +162,12 @@ export function buildResumeHydrationPlan({
     : resumedTurnState.activeTurnId;
   const shouldMarkProcessing = keepLocalProcessing || Boolean(resumedActiveTurnId);
   const processingTimestamp = resumedTurnState.activeTurnStartedAtMs ?? Date.now();
+  const localItemIds =
+    items.length > 0 && localItems.length > 0
+      ? new Set(localItems.map((local) => local.id))
+      : null;
   const hasOverlap =
-    items.length > 0 &&
-    localItems.length > 0 &&
-    items.some((item) => localItems.some((local) => local.id === item.id));
+    localItemIds !== null && items.some((item) => localItemIds.has(item.id));
   const mergedItems =
     items.length > 0
       ? replaceLocal


### PR DESCRIPTION
## Summary
Long thread resume could become very slow because overlap detection in resume hydration used nested scans:

- `items.some(...)` + `localItems.some(...)` (quadratic in combined list size)

This change replaces that with a `Set` of local item IDs and O(1) membership checks.

## What changed
- In `buildResumeHydrationPlan` (`src/features/threads/utils/threadActionHelpers.ts`):
  - build `localItemIds = new Set(localItems.map(item => item.id))`
  - replace nested overlap check with `items.some(item => localItemIds.has(item.id))`

## Why
For long threads, this removes a hot O(n²) path during resume while keeping behavior identical.

## Validation
- `npm run -s typecheck`
- `npm run -s test -- src/features/threads/hooks/useThreadActions.test.tsx src/features/threads/hooks/useThreads.integration.test.tsx src/features/app/hooks/useRemoteThreadRefreshOnFocus.test.tsx src/utils/threadItems.test.ts`
- Built and tested `aarch64` AppImage locally.
