### PR TITLE
[codex] Add default service tier setting

### DIFF
--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -485,6 +485,8 @@ pub(crate) struct AppSettings {
     pub(crate) last_composer_model_id: Option<String>,
     #[serde(default, rename = "lastComposerReasoningEffort")]
     pub(crate) last_composer_reasoning_effort: Option<String>,
+    #[serde(default, rename = "lastComposerServiceTier")]
+    pub(crate) last_composer_service_tier: Option<String>,
     #[serde(default = "default_ui_scale", rename = "uiScale")]
     pub(crate) ui_scale: f64,
     #[serde(default = "default_theme", rename = "theme")]
@@ -1153,6 +1155,7 @@ impl Default for AppSettings {
             cycle_workspace_prev_shortcut: default_cycle_workspace_prev_shortcut(),
             last_composer_model_id: None,
             last_composer_reasoning_effort: None,
+            last_composer_service_tier: None,
             ui_scale: 1.0,
             theme: default_theme(),
             usage_show_remaining: default_usage_show_remaining(),
@@ -1319,6 +1322,7 @@ mod tests {
         );
         assert!(settings.last_composer_model_id.is_none());
         assert!(settings.last_composer_reasoning_effort.is_none());
+        assert!(settings.last_composer_service_tier.is_none());
         assert!((settings.ui_scale - 1.0).abs() < f64::EPSILON);
         assert_eq!(settings.theme, "system");
         assert!(!settings.usage_show_remaining);
@@ -1385,6 +1389,7 @@ mod tests {
             sort_order: Some(2),
             copies_folder: Some("/tmp/group-copies".to_string()),
         }];
+        settings.last_composer_service_tier = Some("fast".to_string());
 
         let json = serde_json::to_string(&settings).expect("serialize settings");
         let decoded: AppSettings = serde_json::from_str(&json).expect("deserialize settings");
@@ -1392,6 +1397,10 @@ mod tests {
         assert_eq!(
             decoded.workspace_groups[0].copies_folder.as_deref(),
             Some("/tmp/group-copies")
+        );
+        assert_eq!(
+            decoded.last_composer_service_tier.as_deref(),
+            Some("fast")
         );
     }
 

--- a/src/features/app/components/MainApp.tsx
+++ b/src/features/app/components/MainApp.tsx
@@ -670,6 +670,7 @@ export default function MainApp() {
       defaultAccessMode: appSettings.defaultAccessMode,
       lastComposerModelId: appSettings.lastComposerModelId,
       lastComposerReasoningEffort: appSettings.lastComposerReasoningEffort,
+      lastComposerServiceTier: appSettings.lastComposerServiceTier,
     },
     threadCodexParamsVersion,
     getThreadCodexParams,

--- a/src/features/app/orchestration/useThreadOrchestration.test.ts
+++ b/src/features/app/orchestration/useThreadOrchestration.test.ts
@@ -59,6 +59,7 @@ function makeSyncParams(
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
     },
     threadCodexParamsVersion: 0,
     getThreadCodexParams,
@@ -146,6 +147,24 @@ describe("useThreadSelectionHandlersOrchestration codex args selection", () => {
     expect(params.persistThreadCodexParams).toHaveBeenCalledWith({
       serviceTier: "fast",
     });
+  });
+
+  it("persists service tier selections as the global default when no thread is active", () => {
+    const params = makeSelectionParams();
+    const { result } = renderHook(() => useThreadSelectionHandlersOrchestration(params));
+
+    act(() => {
+      result.current.handleSelectServiceTier("fast");
+    });
+
+    expect(params.setAppSettings).toHaveBeenCalledTimes(1);
+    const update = vi.mocked(params.setAppSettings).mock.calls[0]?.[0] as (
+      current: AppSettings,
+    ) => AppSettings;
+    const nextSettings = update({ lastComposerServiceTier: null } as AppSettings);
+
+    expect(nextSettings.lastComposerServiceTier).toBe("fast");
+    expect(params.queueSaveSettings).toHaveBeenCalledWith(nextSettings);
   });
 
   it("normalizes smart quotes/dashes before persisting selected override", () => {

--- a/src/features/app/orchestration/useThreadOrchestration.ts
+++ b/src/features/app/orchestration/useThreadOrchestration.ts
@@ -57,7 +57,10 @@ type UseThreadCodexSyncOrchestrationParams = {
   activeThreadId: string | null;
   appSettings: Pick<
     AppSettings,
-    "defaultAccessMode" | "lastComposerModelId" | "lastComposerReasoningEffort"
+    | "defaultAccessMode"
+    | "lastComposerModelId"
+    | "lastComposerReasoningEffort"
+    | "lastComposerServiceTier"
   >;
   threadCodexParamsVersion: number;
   getThreadCodexParams: ReturnType<typeof useThreadCodexParams>["getThreadCodexParams"];
@@ -165,6 +168,7 @@ export function useThreadCodexSyncOrchestration({
       defaultAccessMode: appSettings.defaultAccessMode,
       lastComposerModelId: appSettings.lastComposerModelId,
       lastComposerReasoningEffort: appSettings.lastComposerReasoningEffort,
+      lastComposerServiceTier: appSettings.lastComposerServiceTier,
       stored,
       noThreadStored,
       pendingSeed: pendingNewThreadSeedRef.current,
@@ -183,6 +187,7 @@ export function useThreadCodexSyncOrchestration({
     appSettings.defaultAccessMode,
     appSettings.lastComposerModelId,
     appSettings.lastComposerReasoningEffort,
+    appSettings.lastComposerServiceTier,
     getThreadCodexParams,
     setPreferredCollabModeId,
     setPreferredCodexArgsOverride,
@@ -342,9 +347,28 @@ export function useThreadSelectionHandlersOrchestration({
   const handleSelectServiceTier = useCallback(
     (tier: ServiceTier | null | undefined) => {
       setSelectedServiceTier(tier);
+      const hasActiveThread = Boolean(activeThreadIdRef.current);
+      if (!appSettingsLoading && !hasActiveThread) {
+        setAppSettings((current) => {
+          const nextTier = tier ?? null;
+          if (current.lastComposerServiceTier === nextTier) {
+            return current;
+          }
+          const nextSettings = { ...current, lastComposerServiceTier: nextTier };
+          void queueSaveSettings(nextSettings);
+          return nextSettings;
+        });
+      }
       persistThreadCodexParams({ serviceTier: tier });
     },
-    [persistThreadCodexParams, setSelectedServiceTier],
+    [
+      activeThreadIdRef,
+      appSettingsLoading,
+      persistThreadCodexParams,
+      queueSaveSettings,
+      setAppSettings,
+      setSelectedServiceTier,
+    ],
   );
 
   const handleSelectCollaborationMode = useCallback(

--- a/src/features/settings/components/SettingsView.test.tsx
+++ b/src/features/settings/components/SettingsView.test.tsx
@@ -107,6 +107,7 @@ const baseSettings: AppSettings = {
   cycleWorkspacePrevShortcut: null,
   lastComposerModelId: null,
   lastComposerReasoningEffort: null,
+  lastComposerServiceTier: null,
   uiScale: 1,
   theme: "system",
   usageShowRemaining: false,
@@ -1661,6 +1662,7 @@ describe("SettingsView Codex defaults", () => {
     const effortSelect = screen.getByLabelText(
       "Reasoning effort",
     ) as HTMLSelectElement;
+    const serviceTierSelect = screen.getByLabelText("Service tier") as HTMLSelectElement;
 
     await waitFor(() => {
       expect(modelSelect.disabled).toBe(false);
@@ -1685,6 +1687,15 @@ describe("SettingsView Codex defaults", () => {
     await waitFor(() => {
       expect(onUpdateAppSettings).toHaveBeenCalledWith(
         expect.objectContaining({ lastComposerReasoningEffort: "high" }),
+      );
+    });
+
+    onUpdateAppSettings.mockClear();
+    fireEvent.change(serviceTierSelect, { target: { value: "fast" } });
+
+    await waitFor(() => {
+      expect(onUpdateAppSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ lastComposerServiceTier: "fast" }),
       );
     });
   });

--- a/src/features/settings/components/sections/SettingsCodexSection.tsx
+++ b/src/features/settings/components/sections/SettingsCodexSection.tsx
@@ -6,6 +6,7 @@ import type {
   CodexDoctorResult,
   CodexUpdateResult,
   ModelOption,
+  ServiceTier,
 } from "@/types";
 import {
   SettingsSection,
@@ -69,6 +70,13 @@ const normalizeEffortValue = (value: unknown): string | null => {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+};
+
+const normalizeServiceTierValue = (value: unknown): ServiceTier | null => {
+  if (value === "fast" || value === "flex") {
+    return value;
+  }
+  return null;
 };
 
 function coerceSavedModelSlug(value: string | null, models: ModelOption[]): string | null {
@@ -184,6 +192,10 @@ export function SettingsCodexSection({
     }
     return reasoningOptions[0] ?? "";
   }, [reasoningOptions, reasoningSupported, savedEffort, selectedModel]);
+  const selectedServiceTier = useMemo(
+    () => normalizeServiceTierValue(appSettings.lastComposerServiceTier),
+    [appSettings.lastComposerServiceTier],
+  );
 
   const didNormalizeDefaultsRef = useRef(false);
   useEffect(() => {
@@ -472,6 +484,33 @@ export function SettingsCodexSection({
               {effort}
             </option>
           ))}
+        </select>
+      </SettingsToggleRow>
+
+      <SettingsToggleRow
+        title={
+          <label htmlFor="default-service-tier">
+            Service tier
+          </label>
+        }
+        subtitle="Used when there is no thread-specific override. Choose Fast to default new projects to Fast mode."
+      >
+        <select
+          id="default-service-tier"
+          className="settings-select"
+          value={selectedServiceTier ?? ""}
+          onChange={(event) => {
+            const nextTier = normalizeServiceTierValue(event.target.value);
+            void onUpdateAppSettings({
+              ...appSettings,
+              lastComposerServiceTier: nextTier,
+            });
+          }}
+          aria-label="Service tier"
+        >
+          <option value="">default / off</option>
+          <option value="fast">fast</option>
+          <option value="flex">flex</option>
         </select>
       </SettingsToggleRow>
 

--- a/src/features/settings/hooks/useAppSettings.ts
+++ b/src/features/settings/hooks/useAppSettings.ts
@@ -23,6 +23,7 @@ import { DEFAULT_COMMIT_MESSAGE_PROMPT } from "@utils/commitMessagePrompt";
 const allowedThemes = new Set(["system", "light", "dark", "dim"]);
 const allowedPersonality = new Set(["friendly", "pragmatic"]);
 const allowedFollowUpMessageBehavior = new Set(["queue", "steer"]);
+const allowedServiceTiers = new Set(["fast", "flex"]);
 const DEFAULT_REMOTE_BACKEND_HOST = "127.0.0.1:4732";
 const DEFAULT_REMOTE_BACKEND_ID = "remote-default";
 const DEFAULT_REMOTE_BACKEND_NAME = "Primary remote";
@@ -165,6 +166,7 @@ function buildDefaultSettings(): AppSettings {
     cycleWorkspacePrevShortcut: isMac ? "cmd+shift+up" : "ctrl+alt+shift+up",
     lastComposerModelId: null,
     lastComposerReasoningEffort: null,
+    lastComposerServiceTier: null,
     uiScale: UI_SCALE_DEFAULT,
     theme: "system",
     usageShowRemaining: false,
@@ -259,6 +261,11 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     personality: allowedPersonality.has(settings.personality)
       ? settings.personality
       : "friendly",
+    lastComposerServiceTier:
+      settings.lastComposerServiceTier &&
+      allowedServiceTiers.has(settings.lastComposerServiceTier)
+        ? settings.lastComposerServiceTier
+        : null,
     followUpMessageBehavior: allowedFollowUpMessageBehavior.has(
       settings.followUpMessageBehavior,
     )

--- a/src/features/threads/utils/threadCodexParamsSeed.test.ts
+++ b/src/features/threads/utils/threadCodexParamsSeed.test.ts
@@ -57,6 +57,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
       stored: {
         modelId: "gpt-4.1",
         effort: "low",
@@ -92,6 +93,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
       stored: null,
       noThreadStored: null,
       pendingSeed: {
@@ -119,6 +121,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
       stored: {
         modelId: null,
         effort: null,
@@ -146,6 +149,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
       stored: {
         modelId: null,
         effort: null,
@@ -173,6 +177,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
       stored: {
         modelId: null,
         effort: null,
@@ -206,6 +211,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: "fast",
       stored: {
         modelId: "gpt-4.1",
         effort: "low",
@@ -230,6 +236,36 @@ describe("threadCodexParamsSeed", () => {
     });
   });
 
+  it("falls back to the saved service tier default when workspace state is unset", () => {
+    const noThreadResolved = resolveThreadCodexState({
+      workspaceId: "ws-1",
+      threadId: null,
+      defaultAccessMode: "current",
+      lastComposerModelId: "gpt-5",
+      lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: "fast",
+      stored: null,
+      noThreadStored: null,
+      pendingSeed: null,
+    });
+
+    expect(noThreadResolved.preferredServiceTier).toBe("fast");
+
+    const threadResolved = resolveThreadCodexState({
+      workspaceId: "ws-1",
+      threadId: "thread-1",
+      defaultAccessMode: "current",
+      lastComposerModelId: "gpt-5",
+      lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: "fast",
+      stored: null,
+      noThreadStored: null,
+      pendingSeed: null,
+    });
+
+    expect(threadResolved.preferredServiceTier).toBe("fast");
+  });
+
   it("keeps explicit thread-scoped Fast off when no-thread scope is fast", () => {
     const resolved = resolveThreadCodexState({
       workspaceId: "ws-1",
@@ -237,6 +273,7 @@ describe("threadCodexParamsSeed", () => {
       defaultAccessMode: "current",
       lastComposerModelId: "gpt-5",
       lastComposerReasoningEffort: "medium",
+      lastComposerServiceTier: null,
       stored: {
         modelId: null,
         effort: null,

--- a/src/features/threads/utils/threadCodexParamsSeed.ts
+++ b/src/features/threads/utils/threadCodexParamsSeed.ts
@@ -22,6 +22,7 @@ type ResolveThreadCodexStateInput = {
   defaultAccessMode: AccessMode;
   lastComposerModelId: string | null;
   lastComposerReasoningEffort: string | null;
+  lastComposerServiceTier: ServiceTier | null;
   stored: ThreadCodexParams | null;
   noThreadStored: ThreadCodexParams | null;
   pendingSeed: PendingNewThreadSeed | null;
@@ -120,6 +121,7 @@ export function resolveThreadCodexState(
     defaultAccessMode,
     lastComposerModelId,
     lastComposerReasoningEffort,
+    lastComposerServiceTier,
     stored,
     noThreadStored,
     pendingSeed,
@@ -131,7 +133,10 @@ export function resolveThreadCodexState(
       accessMode: stored?.accessMode ?? defaultAccessMode,
       preferredModelId: stored?.modelId ?? lastComposerModelId ?? null,
       preferredEffort: stored?.effort ?? lastComposerReasoningEffort ?? null,
-      preferredServiceTier: stored?.serviceTier,
+      preferredServiceTier:
+        stored?.serviceTier !== undefined
+          ? stored.serviceTier
+          : lastComposerServiceTier ?? undefined,
       preferredCollabModeId: stored?.collaborationModeId ?? null,
       preferredCodexArgsOverride: stored?.codexArgsOverride ?? null,
     };
@@ -148,7 +153,7 @@ export function resolveThreadCodexState(
     preferredServiceTier:
       stored?.serviceTier !== undefined
         ? stored.serviceTier
-        : noThreadStored?.serviceTier,
+        : noThreadStored?.serviceTier ?? lastComposerServiceTier ?? undefined,
     preferredCollabModeId:
       stored?.collaborationModeId ??
       (pendingForWorkspace

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,7 @@ export type AppSettings = {
   cycleWorkspacePrevShortcut: string | null;
   lastComposerModelId: string | null;
   lastComposerReasoningEffort: string | null;
+  lastComposerServiceTier: ServiceTier | null;
   uiScale: number;
   theme: ThemePreference;
   usageShowRemaining: boolean;


### PR DESCRIPTION
## What changed

This adds a persistent default service tier setting to CodexMonitor and exposes it in Settings under `Codex -> Default parameters`.

Users can now choose a default `Service tier` (`default / off`, `fast`, or `flex`) that applies whenever a workspace or thread does not already have a thread-scoped override.

## Why this changed

Fast mode was previously only persisted as workspace-local UI state in thread parameter storage. That meant existing workspaces could remember Fast mode once `/fast` had been used, but newly created projects did not inherit any default and always started with Fast mode off.

Model and reasoning effort already had app-level defaults, but service tier did not. This change makes service tier behave consistently with those existing defaults.

## User impact

Users can now set Fast mode as the default for new projects without needing to run `/fast` in each workspace.

Behavior after this change:
- existing explicit per-thread service tier overrides still win
- an explicit thread-scoped `off` (`null`) still disables Fast mode
- when no workspace/thread override exists, CodexMonitor falls back to the saved global default service tier

## Root cause

`serviceTier` was stored only in thread/workspace local storage, while `AppSettings` persisted only `lastComposerModelId` and `lastComposerReasoningEffort`. New projects therefore had no saved `__no_thread__` service tier seed to inherit from.

## Validation

- `npm run typecheck`
- `npm run test -- src/features/app/orchestration/useThreadOrchestration.test.ts src/features/threads/utils/threadCodexParamsSeed.test.ts src/features/settings/components/SettingsView.test.tsx`

## Notes

I did not run Rust-side compilation in this environment because the local machine did not have the Rust toolchain installed yet.
