### PR TITLE
Add Ubuntu 22.04 support for Linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           - name: macOS
             os: macos-latest
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - name: Windows
             os: windows-latest
     steps:
@@ -113,7 +113,7 @@ jobs:
             os: macos-latest
             build_command: npm run tauri -- build --debug --no-bundle
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
             build_command: npm run tauri -- build --debug --no-bundle
           - name: Windows
             os: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,9 +177,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-24.04
+          # Build on oldest supported Ubuntu baseline for broader runtime compatibility.
+          - platform: ubuntu-22.04
             arch: x86_64
-          - platform: ubuntu-24.04-arm
+          - platform: ubuntu-22.04-arm
             arch: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is a small workflow-only change that moves the Linux CI and release builds to Ubuntu 22.04. Ubuntu 22.04 is about four years old now, but it is still the baseline in some environments, including Ubuntu AWS WorkSpaces, so building there should help keep the released Linux artifacts usable on those systems without changing any product code.

I used Codex to prepare the workflow update, and I also built and tested the app directly on Ubuntu 22.04, where it worked fine. The full PR checks are passing as well, including the JavaScript test suite and Linux Tauri build.
